### PR TITLE
Dispatch cancelable server:livereload event before reloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "publish": "pnpm run build && lerna publish from-package --yes",
     "rewritepackagefiles": "node rewritepackagefiles.js",
     "start": "server --resolve-modules",
-    "test": "eslint packages",
+    "test": "eslint packages && pnpm -r run test",
     "update": "pnpm i",
     "upgrade": "syncpack update && syncpack fix && pnpm i",
     "version": "lerna version"

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -3,3 +3,18 @@
 Simple live reloading HTTP2 server for development
 
 `npx run server [--path=.] [--watchpath=.] [--verbose]`
+
+## Opting out of automatic reloads
+
+Before reloading on a file change or reconnect, the injected live-reload client
+dispatches a cancelable `server:livereload` event
+(`CustomEvent<{ reason: 'change' | 'reconnect' }>`) on `window`. Call
+`event.preventDefault()` to take over the update yourself — for example to show
+a manual refresh control instead of reloading the page:
+
+```js
+window.addEventListener('server:livereload', (event) => {
+  event.preventDefault();
+  showRefreshButton();
+});
+```

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,8 @@
   "types": "dist/index.d.ts",
   "bin": "dist/bin/index.js",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "node --test --test-force-exit src/*.test.ts"
   },
   "dependencies": {
     "chokidar": "^5.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,7 +23,7 @@
   "bin": "dist/bin/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "node --test --test-force-exit src/*.test.ts"
+    "test": "node --test src/*.test.ts"
   },
   "dependencies": {
     "chokidar": "^5.0.0",

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -66,9 +66,11 @@ describe('live-reload client script', () => {
     await writeFile(join(rootPath, 'index.html'), '<html><head><title>test</title></head><body></body></html>');
     // The Server API has no ephemeral-port mode (get-port rejects ports below
     // 1024), so ask for high bases and let it scan upward from there when busy;
-    // the actually-bound port is read back from the socket either way.
+    // the actually-bound port is read back from the socket either way. The bases
+    // sit more than one scan range (100 ports) apart so the two can never
+    // collide on the same port.
     watchingServer = new Server({ rootPath, watch: true, port: 8801 });
-    plainServer = new Server({ rootPath, watch: false, port: 8901 });
+    plainServer = new Server({ rootPath, watch: false, port: 9001 });
     await Promise.all([watchingServer.ready, plainServer.ready]);
     watchingPage = await fetchBody(boundPort(watchingServer), '/index.html');
   });

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -1,0 +1,67 @@
+import { ok } from 'node:assert';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect } from 'node:http2';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+import { Server } from './server.ts';
+
+async function fetchBody(port: number, path: string): Promise<string> {
+  const session = connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+  try {
+    return await new Promise<string>((resolvePromise, rejectPromise) => {
+      session.on('error', rejectPromise);
+      const stream = session.request({ ':path': path });
+      let body = '';
+      stream.setEncoding('utf8');
+      stream.on('data', (chunk: string) => {
+        body += chunk;
+      });
+      stream.on('end', () => resolvePromise(body));
+      stream.on('error', rejectPromise);
+    });
+  }
+  finally {
+    session.close();
+  }
+}
+
+function boundPort(server: Server): number {
+  const address = server.http2SecureServer.address();
+  if (address === null || typeof address === 'string') throw new Error('server has no bound port');
+  return address.port;
+}
+
+describe('live-reload client script', () => {
+  let rootPath: string;
+  let watchingServer: Server;
+  let plainServer: Server;
+
+  before(async () => {
+    rootPath = await mkdtemp(join(tmpdir(), 'server-test-'));
+    await writeFile(join(rootPath, 'index.html'), '<html><head><title>test</title></head><body></body></html>');
+    watchingServer = new Server({ rootPath, watch: true, port: 8801 });
+    plainServer = new Server({ rootPath, watch: false, port: 8901 });
+    await Promise.all([watchingServer.ready, plainServer.ready]);
+  });
+
+  after(async () => {
+    watchingServer.http2SecureServer.close();
+    plainServer.http2SecureServer.close();
+    await rm(rootPath, { recursive: true, force: true });
+  });
+
+  it('announces changes through a cancelable server:livereload event before reloading', async () => {
+    const body = await fetchBody(boundPort(watchingServer), '/index.html');
+    ok(body.includes('new EventSource'), 'expected the live-reload client to be injected');
+    ok(body.includes('new CustomEvent("server:livereload", { cancelable: true'), 'expected a cancelable server:livereload CustomEvent');
+    ok(body.includes('if (window.dispatchEvent(event)) reload()'), 'expected reload to be skipped when the event is prevented');
+  });
+
+  it('injects nothing when watch is off', async () => {
+    const body = await fetchBody(boundPort(plainServer), '/index.html');
+    ok(!body.includes('EventSource'), 'expected no live-reload client without watch');
+    ok(!body.includes('server:livereload'), 'expected no livereload event wiring without watch');
+  });
+});

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -1,4 +1,4 @@
-import { ok } from 'node:assert';
+import { ok, strictEqual } from 'node:assert';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { connect } from 'node:http2';
 import { tmpdir } from 'node:os';
@@ -33,17 +33,44 @@ function boundPort(server: Server): number {
   return address.port;
 }
 
+// Run the injected live-reload client against stubbed globals so the tests
+// exercise its actual cancel contract, not just its source text. Node's native
+// EventTarget/CustomEvent implement cancelable dispatch per spec, so no DOM
+// library is needed.
+function runInjectedClient(pageBody: string): { window: EventTarget; eventSource: EventTarget; reloadCount: () => number } {
+  const scriptMatch = pageBody.match(/<script>([\s\S]*?)<\/script>/);
+  ok(scriptMatch, 'expected an injected script in the served page');
+  const windowStub = new EventTarget();
+  let reloads = 0;
+  const locationStub = { reload: () => reloads++ };
+  const instances: EventTarget[] = [];
+  class EventSourceStub extends EventTarget {
+    constructor() {
+      super();
+      instances.push(this);
+    }
+  }
+  new Function('window', 'location', 'EventSource', scriptMatch[1])(windowStub, locationStub, EventSourceStub);
+  strictEqual(instances.length, 1, 'expected the client to open one EventSource');
+  return { window: windowStub, eventSource: instances[0], reloadCount: () => reloads };
+}
+
 describe('live-reload client script', () => {
   let rootPath: string;
   let watchingServer: Server;
   let plainServer: Server;
+  let watchingPage: string;
 
   before(async () => {
     rootPath = await mkdtemp(join(tmpdir(), 'server-test-'));
     await writeFile(join(rootPath, 'index.html'), '<html><head><title>test</title></head><body></body></html>');
+    // The Server API has no ephemeral-port mode (get-port rejects ports below
+    // 1024), so ask for high bases and let it scan upward from there when busy;
+    // the actually-bound port is read back from the socket either way.
     watchingServer = new Server({ rootPath, watch: true, port: 8801 });
     plainServer = new Server({ rootPath, watch: false, port: 8901 });
     await Promise.all([watchingServer.ready, plainServer.ready]);
+    watchingPage = await fetchBody(boundPort(watchingServer), '/index.html');
   });
 
   after(async () => {
@@ -52,11 +79,36 @@ describe('live-reload client script', () => {
     await rm(rootPath, { recursive: true, force: true });
   });
 
-  it('announces changes through a cancelable server:livereload event before reloading', async () => {
-    const body = await fetchBody(boundPort(watchingServer), '/index.html');
-    ok(body.includes('new EventSource'), 'expected the live-reload client to be injected');
-    ok(body.includes('new CustomEvent("server:livereload", { cancelable: true'), 'expected a cancelable server:livereload CustomEvent');
-    ok(body.includes('if (window.dispatchEvent(event)) reload()'), 'expected reload to be skipped when the event is prevented');
+  it('reloads on a change message when nothing cancels the announcement', () => {
+    const client = runInjectedClient(watchingPage);
+    client.eventSource.dispatchEvent(new Event('message'));
+    strictEqual(client.reloadCount(), 1);
+  });
+
+  it('skips the reload when a server:livereload listener prevents it', () => {
+    const client = runInjectedClient(watchingPage);
+    const reasons: unknown[] = [];
+    client.window.addEventListener('server:livereload', (event) => {
+      event.preventDefault();
+      reasons.push((event as CustomEvent).detail.reason);
+    });
+    client.eventSource.dispatchEvent(new Event('message'));
+    strictEqual(client.reloadCount(), 0, 'a prevented announcement must not reload');
+    strictEqual(reasons[0], 'change');
+  });
+
+  it('announces a reconnect, but not the first connection', () => {
+    const client = runInjectedClient(watchingPage);
+    const reasons: unknown[] = [];
+    client.window.addEventListener('server:livereload', (event) => {
+      event.preventDefault();
+      reasons.push((event as CustomEvent).detail.reason);
+    });
+    client.eventSource.dispatchEvent(new Event('open'));
+    strictEqual(reasons.length, 0, 'the first open is not a reconnect');
+    client.eventSource.dispatchEvent(new Event('open'));
+    strictEqual(reasons[0], 'reconnect');
+    strictEqual(client.reloadCount(), 0);
   });
 
   it('injects nothing when watch is off', async () => {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -76,8 +76,7 @@ describe('live-reload client script', () => {
   });
 
   after(async () => {
-    watchingServer.http2SecureServer.close();
-    plainServer.http2SecureServer.close();
+    await Promise.all([watchingServer.close(), plainServer.close()]);
     await rm(rootPath, { recursive: true, force: true });
   });
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -792,12 +792,18 @@ export class Server {
     forceReload = true;
     location.reload();
   }
+  // Cancelable so a page can take over the reload (event.preventDefault()) and
+  // handle the update itself — e.g. surface a manual refresh control instead.
+  function announce(reason) {
+    const event = new CustomEvent("server:livereload", { cancelable: true, detail: { reason } });
+    if (window.dispatchEvent(event)) reload();
+  }
   const eventSource = new EventSource("${basePrefix}${LIVE_RELOAD_PATH}");
-  eventSource.addEventListener("message", reload);
+  eventSource.addEventListener("message", () => announce("change"));
   // EventSource reconnects on its own; a reconnect after the server (or
   // connection) dropped means we may have missed changes — reload.
   eventSource.addEventListener("open", function () {
-    if (hadConnection) reload();
+    if (hadConnection) announce("reconnect");
     hadConnection = true;
   });
 })();

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -794,6 +794,8 @@ export class Server {
   }
   // Cancelable so a page can take over the reload (event.preventDefault()) and
   // handle the update itself — e.g. surface a manual refresh control instead.
+  // A canceled event also skips reload()'s forceReload side effect, so the
+  // navigation suppression above only ever arms for an actual reload.
   function announce(reason) {
     const event = new CustomEvent("server:livereload", { cancelable: true, detail: { reason } });
     if (window.dispatchEvent(event)) reload();
@@ -980,5 +982,17 @@ export class Server {
         stream.write('data: refresh\n\n');
       }
     }
+  }
+
+  // Stop everything that keeps the process alive: the polling watcher, the
+  // held-open live-reload streams, and the listening socket.
+  async close(): Promise<void> {
+    await this.#watcher?.close();
+    for (const stream of this.#liveReloadStreams) {
+      stream.destroy();
+    }
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      this.http2SecureServer.close(error => (error ? rejectPromise(error) : resolvePromise()));
+    });
   }
 }


### PR DESCRIPTION
Implements the lib side of damienmortini/playground#19 (manual refresh button plan).

The injected live-reload client reloaded unconditionally on a file change or SSE reconnect. It now dispatches a cancelable `server:livereload` CustomEvent on `window` first — with no listener attached, `window.dispatchEvent` returns `true` and the reload happens exactly as before, so existing consumers are unaffected. A page can call `event.preventDefault()` to take over the update itself (the playground will use this to show a manual refresh button instead of reloading under the user). `event.detail.reason` carries `'change'` or `'reconnect'`.

Adds `server.test.ts` (`node --test`) covering: the injected script carries the cancelable event wiring, and a `watch: false` server injects nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)