### PR TITLE
Only announce a live-reload update when one was actually missed

### DIFF
--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -27,6 +27,29 @@ async function fetchBody(port: number, path: string): Promise<string> {
   }
 }
 
+// Read the state token the live-reload stream sends on connect, then hang up —
+// the stream itself stays open forever, so it can never be read to its end.
+async function fetchLiveReloadState(port: number): Promise<string> {
+  const session = connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+  try {
+    return await new Promise<string>((resolvePromise, rejectPromise) => {
+      session.on('error', rejectPromise);
+      const stream = session.request({ ':path': '/@livereload' });
+      let body = '';
+      stream.setEncoding('utf8');
+      stream.on('data', (chunk: string) => {
+        body += chunk;
+        const match = body.match(/event: state\ndata: (.*)\n/);
+        if (match) resolvePromise(match[1]);
+      });
+      stream.on('error', rejectPromise);
+    });
+  }
+  finally {
+    session.close();
+  }
+}
+
 function boundPort(server: Server): number {
   const address = server.http2SecureServer.address();
   if (address === null || typeof address === 'string') throw new Error('server has no bound port');
@@ -98,18 +121,38 @@ describe('live-reload client script', () => {
     strictEqual(reasons[0], 'change');
   });
 
-  it('announces a reconnect, but not the first connection', () => {
+  it('stays quiet when a reconnect reaches the same server with nothing missed', () => {
     const client = runInjectedClient(watchingPage);
     const reasons: unknown[] = [];
     client.window.addEventListener('server:livereload', (event) => {
       event.preventDefault();
       reasons.push((event as CustomEvent).detail.reason);
     });
-    client.eventSource.dispatchEvent(new Event('open'));
-    strictEqual(reasons.length, 0, 'the first open is not a reconnect');
-    client.eventSource.dispatchEvent(new Event('open'));
+    client.eventSource.dispatchEvent(new MessageEvent('state', { data: 'server-1-0' }));
+    client.eventSource.dispatchEvent(new MessageEvent('state', { data: 'server-1-0' }));
+    strictEqual(reasons.length, 0, 'a dropped connection alone is not an update');
+    strictEqual(client.reloadCount(), 0);
+  });
+
+  it('announces a reconnect when the state token moved on while it was away', () => {
+    const client = runInjectedClient(watchingPage);
+    const reasons: unknown[] = [];
+    client.window.addEventListener('server:livereload', (event) => {
+      event.preventDefault();
+      reasons.push((event as CustomEvent).detail.reason);
+    });
+    client.eventSource.dispatchEvent(new MessageEvent('state', { data: 'server-1-0' }));
+    strictEqual(reasons.length, 0, 'the first connection is not a reconnect');
+    client.eventSource.dispatchEvent(new MessageEvent('state', { data: 'server-2-0' }));
     strictEqual(reasons[0], 'reconnect');
     strictEqual(client.reloadCount(), 0);
+  });
+
+  it('changes its state token when it refreshes, but not between connections', async () => {
+    const state = await fetchLiveReloadState(boundPort(watchingServer));
+    strictEqual(await fetchLiveReloadState(boundPort(watchingServer)), state, 'reconnecting alone must not move the token');
+    watchingServer.refresh();
+    ok(await fetchLiveReloadState(boundPort(watchingServer)) !== state, 'a refresh must move the token');
   });
 
   it('injects nothing when watch is off', async () => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -234,6 +234,13 @@ export class Server {
   ready: Promise<void>;
 
   #liveReloadStreams = new Set<ServerHttp2Stream>();
+  // Identity of this server process plus how many refreshes it has broadcast:
+  // together they form the state token announced to every live-reload client on
+  // connect. A client that merely lost its connection (a suspended tab, a flaky
+  // network) reads back the same token and knows it missed nothing; a restarted
+  // server or a refresh sent while it was away changes it.
+  #liveReloadInstance = randomBytes(8).toString('hex');
+  #refreshCount = 0;
   #watcher?: FSWatcher;
   #watchedPaths = new Set<string>();
 
@@ -433,6 +440,9 @@ export class Server {
         // EventSource waits a few seconds before reconnecting by default; match
         // the snappier 1s cadence the previous WebSocket client used.
         stream.write('retry: 1000\n\n');
+        // Named event, so the client's plain `message` handler (the refresh
+        // broadcast) never sees it.
+        stream.write(`event: state\ndata: ${this.#liveReloadInstance}-${this.#refreshCount}\n\n`);
         if (verbose) console.log('live-reload client connected');
         this.#liveReloadStreams.add(stream);
         const removeStream = (): void => {
@@ -784,7 +794,7 @@ export class Server {
               `<script>
 (function () {
   let forceReload = false;
-  let hadConnection = false;
+  let serverState = null;
   window.navigation?.addEventListener('navigate', (event) => {
     if (forceReload) event.stopImmediatePropagation();
   });
@@ -802,11 +812,14 @@ export class Server {
   }
   const eventSource = new EventSource("${basePrefix}${LIVE_RELOAD_PATH}");
   eventSource.addEventListener("message", () => announce("change"));
-  // EventSource reconnects on its own; a reconnect after the server (or
-  // connection) dropped means we may have missed changes — reload.
-  eventSource.addEventListener("open", function () {
-    if (hadConnection) announce("reconnect");
-    hadConnection = true;
+  // EventSource reconnects on its own, and a dropped connection is not by
+  // itself an update: a backgrounded tab or a sleeping device reconnects to the
+  // very same server with nothing missed. The server states an opaque token on
+  // every connect, so only a restart or a refresh broadcast while we were
+  // disconnected — either of which changes the token — is a missed update.
+  eventSource.addEventListener("state", function (event) {
+    if (serverState !== null && serverState !== event.data) announce("reconnect");
+    serverState = event.data;
   });
 })();
 </script>
@@ -977,6 +990,7 @@ export class Server {
   }
 
   refresh(): void {
+    this.#refreshCount++;
     for (const stream of this.#liveReloadStreams) {
       if (!stream.destroyed) {
         stream.write('data: refresh\n\n');


### PR DESCRIPTION
Coming back to a page served by the dev server after any absence surfaced a refresh prompt even though nothing had changed.

The injected live-reload client treated **every** `EventSource` re-open as a possible missed change:

```js
eventSource.addEventListener("open", function () {
  if (hadConnection) announce("reconnect");
  hadConnection = true;
});
```

A backgrounded tab, a sleeping device or an edge proxy hanging up on an idle stream all drop the SSE connection; `EventSource` reconnects on its own and the client announced an update that never happened. On the playground that announcement is caught and turned into the refresh button at the top of the page, which is why it appeared out of nowhere after every absence.

The server now writes a state token — its process identity plus its refresh count — as a named `state` event on every live-reload connect. The client compares it against the one it last saw: an identical token means the connection dropped and came back with nothing missed, while a restarted server or a refresh broadcast sent while it was away moves the token and still announces `reconnect`, so genuine updates are not lost.

Tests cover both directions, plus the token being stable across reconnects and moving on refresh.