### PR TITLE
Honor X-Forwarded-Prefix as a per-request base

### DIFF
--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /dist
 /certificates
+/server-test-fixture-*

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -196,6 +196,13 @@ describe('forwarded prefix', () => {
     ok(body.includes('new EventSource("/@livereload")'), 'expected the live-reload path at the origin root');
   });
 
+  it('falls back to the configured base when the announced prefix is not a plain path', async () => {
+    for (const malformedPrefix of ['../../etc', '/mounted/../app', '/spaced value', `/${'a'.repeat(300)}`]) {
+      const body = await fetchBody(boundPort(server), '/index.html', { 'x-forwarded-prefix': malformedPrefix });
+      ok(body.includes('new EventSource("/@livereload")'), `expected the fallback to the configured base for ${JSON.stringify(malformedPrefix)}`);
+    }
+  });
+
   it('rewrites module specifiers under the announced prefix without poisoning the unprefixed variant', async () => {
     const unprefixed = await fetchBody(boundPort(server), '/module.js');
     ok(unprefixed.includes(`'/${fixturePath}/node_modules/demo-package/index.js'`), `expected an unprefixed rewritten specifier, got: ${unprefixed}`);

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -1,5 +1,5 @@
 import { ok, strictEqual } from 'node:assert';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { connect } from 'node:http2';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -7,12 +7,12 @@ import { after, before, describe, it } from 'node:test';
 
 import { Server } from './server.ts';
 
-async function fetchBody(port: number, path: string): Promise<string> {
+async function fetchBody(port: number, path: string, requestHeaders: Record<string, string> = {}): Promise<string> {
   const session = connect(`https://localhost:${port}`, { rejectUnauthorized: false });
   try {
     return await new Promise<string>((resolvePromise, rejectPromise) => {
       session.on('error', rejectPromise);
-      const stream = session.request({ ':path': path });
+      const stream = session.request({ ':path': path, ...requestHeaders });
       let body = '';
       stream.setEncoding('utf8');
       stream.on('data', (chunk: string) => {
@@ -159,5 +159,49 @@ describe('live-reload client script', () => {
     const body = await fetchBody(boundPort(plainServer), '/index.html');
     ok(!body.includes('EventSource'), 'expected no live-reload client without watch');
     ok(!body.includes('server:livereload'), 'expected no livereload event wiring without watch');
+  });
+});
+
+describe('forwarded prefix', () => {
+  // Module resolution anchors on the process working directory, so the fixture
+  // with its own node_modules lives inside it — a tmpdir root would leave bare
+  // specifiers unresolvable and the rewrite untestable.
+  let fixturePath: string;
+  let server: Server;
+
+  before(async () => {
+    fixturePath = await mkdtemp('server-test-fixture-');
+    await mkdir(join(fixturePath, 'node_modules', 'demo-package'), { recursive: true });
+    await writeFile(join(fixturePath, 'node_modules', 'demo-package', 'package.json'), '{"name":"demo-package","main":"index.js"}');
+    await writeFile(join(fixturePath, 'node_modules', 'demo-package', 'index.js'), 'export const demo = true;');
+    await writeFile(join(fixturePath, 'module.js'), 'import { demo } from \'demo-package\';\nconsole.log(demo);');
+    await writeFile(join(fixturePath, 'index.html'), '<html><head><title>test</title></head><body></body></html>');
+    server = new Server({ rootPath: fixturePath, watch: true, resolveModules: true, port: 9201 });
+    await server.ready;
+  });
+
+  after(async () => {
+    await server.close();
+    await rm(fixturePath, { recursive: true, force: true });
+  });
+
+  it('strips the announced prefix from the request path and emits it in the live-reload path', async () => {
+    const body = await fetchBody(boundPort(server), '/mounted/app/index.html', { 'x-forwarded-prefix': '/mounted/app' });
+    ok(body.includes('<title>test</title>'), 'expected the page behind the prefix to be served');
+    ok(body.includes('new EventSource("/mounted/app/@livereload")'), 'expected the live-reload path under the prefix');
+  });
+
+  it('serves unprefixed requests untouched when no prefix is announced', async () => {
+    const body = await fetchBody(boundPort(server), '/index.html');
+    ok(body.includes('new EventSource("/@livereload")'), 'expected the live-reload path at the origin root');
+  });
+
+  it('rewrites module specifiers under the announced prefix without poisoning the unprefixed variant', async () => {
+    const unprefixed = await fetchBody(boundPort(server), '/module.js');
+    ok(unprefixed.includes(`'/${fixturePath}/node_modules/demo-package/index.js'`), `expected an unprefixed rewritten specifier, got: ${unprefixed}`);
+    const prefixed = await fetchBody(boundPort(server), '/mounted/app/module.js', { 'x-forwarded-prefix': '/mounted/app' });
+    ok(prefixed.includes(`'/mounted/app/${fixturePath}/node_modules/demo-package/index.js'`), `expected a rewritten specifier under the prefix, got: ${prefixed}`);
+    const unprefixedAgain = await fetchBody(boundPort(server), '/module.js');
+    strictEqual(unprefixedAgain, unprefixed, 'expected the prefixed variant to be cached separately');
   });
 });

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -168,6 +168,7 @@ describe('forwarded prefix', () => {
   // specifiers unresolvable and the rewrite untestable.
   let fixturePath: string;
   let server: Server;
+  let basedServer: Server;
 
   before(async () => {
     fixturePath = await mkdtemp('server-test-fixture-');
@@ -177,11 +178,12 @@ describe('forwarded prefix', () => {
     await writeFile(join(fixturePath, 'module.js'), 'import { demo } from \'demo-package\';\nconsole.log(demo);');
     await writeFile(join(fixturePath, 'index.html'), '<html><head><title>test</title></head><body></body></html>');
     server = new Server({ rootPath: fixturePath, watch: true, resolveModules: true, port: 9201 });
-    await server.ready;
+    basedServer = new Server({ rootPath: fixturePath, watch: true, base: 'mounted', port: 9401 });
+    await Promise.all([server.ready, basedServer.ready]);
   });
 
   after(async () => {
-    await server.close();
+    await Promise.all([server.close(), basedServer.close()]);
     await rm(fixturePath, { recursive: true, force: true });
   });
 
@@ -199,8 +201,10 @@ describe('forwarded prefix', () => {
   it('falls back to the configured base when the announced prefix is not a plain path', async () => {
     for (const malformedPrefix of ['../../etc', '/mounted/../app', '/spaced value', `/${'a'.repeat(300)}`]) {
       const body = await fetchBody(boundPort(server), '/index.html', { 'x-forwarded-prefix': malformedPrefix });
-      ok(body.includes('new EventSource("/@livereload")'), `expected the fallback to the configured base for ${JSON.stringify(malformedPrefix)}`);
+      ok(body.includes('new EventSource("/@livereload")'), `expected the fallback to the origin root for ${JSON.stringify(malformedPrefix)}`);
     }
+    const basedBody = await fetchBody(boundPort(basedServer), '/mounted/index.html', { 'x-forwarded-prefix': '../../etc' });
+    ok(basedBody.includes('new EventSource("/mounted/@livereload")'), 'expected the fallback to land on the configured base prefix, not the origin root');
   });
 
   it('rewrites module specifiers under the announced prefix without poisoning the unprefixed variant', async () => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -60,7 +60,7 @@ const COMPRESSIBLE_EXTENSIONS = new Set([
 // Generated responses (transpiled TypeScript, rewritten modules, compressed
 // statics) cached by source path, invalidated by mtime+size; bounded so a big
 // tree can't grow the cache without limit (insertion order doubles as LRU).
-const RESPONSE_CACHE_MAX_ENTRIES = 500;
+const CACHE_MAX_ENTRIES = 500;
 
 type ResponseEntity = {
   body: string | Buffer;
@@ -133,7 +133,9 @@ type ServerOptions = {
    * `/damo/api`). Defaults to root. A reverse proxy can instead announce the
    * prefix per request with the `X-Forwarded-Prefix` header, which overrides
    * this option for that request — so the same server works unprefixed on
-   * localhost and prefixed behind the proxy at the same time.
+   * localhost and prefixed behind the proxy at the same time. The header is
+   * honored from any connection, so a proxy exposed to untrusted networks must
+   * strip client-supplied values before forwarding.
    */
   base?: string;
 };
@@ -146,6 +148,7 @@ function normalizeBasePrefix(value: string | string[] | undefined): string | nul
   const singleValue = Array.isArray(value) ? value[0] : value;
   const normalized = singleValue?.replace(/^\/+|\/+$/g, '');
   if (!normalized || !/^[\w\-./]{1,200}$/.test(normalized)) return null;
+  if (normalized.split('/').some(segment => segment === '.' || segment === '..')) return null;
   return `/${normalized}`;
 }
 
@@ -322,7 +325,7 @@ export class Server {
       }
       responseCache.delete(cacheKey);
       responseCache.set(cacheKey, entry);
-      if (responseCache.size > RESPONSE_CACHE_MAX_ENTRIES) {
+      if (responseCache.size > CACHE_MAX_ENTRIES) {
         responseCache.delete(responseCache.keys().next().value!);
       }
       return entry;
@@ -345,7 +348,13 @@ export class Server {
         const versionChecks = await Promise.all(
           [...cached.dependencyVersions].map(async ([dependencyPath, version]) => await fileVersion(dependencyPath) === version),
         );
-        if (versionChecks.every(Boolean)) return cached.importMap;
+        if (versionChecks.every(Boolean)) {
+          // Re-insertion keeps insertion order tracking recency, like the
+          // response cache.
+          importMapCache.delete(pageServedPath);
+          importMapCache.set(pageServedPath, cached);
+          return cached.importMap;
+        }
       }
       const { importMap, dependencyPaths } = await buildImportMap(htmlContent, pageServedPath, servedRoot);
       // The page file itself is always a dependency: editing its module scripts
@@ -355,6 +364,11 @@ export class Server {
           [dependencyPath, await fileVersion(dependencyPath)]),
       ));
       importMapCache.set(pageServedPath, { importMap, dependencyVersions });
+      // Same cap as the response cache: the key embeds the per-request prefix,
+      // so unique header values must not grow the cache without bound.
+      if (importMapCache.size > CACHE_MAX_ENTRIES) {
+        importMapCache.delete(importMapCache.keys().next().value!);
+      }
       return importMap;
     }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -294,6 +294,9 @@ export class Server {
     // resolved bare-specifier imports are emitted as `/damo/...` so the browser
     // requests them back under the same prefix instead of the origin root.
     const configuredBasePrefix = normalizeBasePrefix(base) ?? '';
+    if (base && !configuredBasePrefix) {
+      console.warn(`base "${base}" is not a plain path — serving from the origin root instead`);
+    }
 
     // Pre-parse proxy URLs once; used by the HTTP proxy and both WebSocket proxy paths.
     const proxyEntries = Object.entries(proxy).map(([proxyPath, target]) => ({

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -98,7 +98,7 @@ function sendCachedBody(
     respondNotModified(stream, entity.etag);
     return;
   }
-  const headersWithValidator: OutgoingHttpHeaders = { ...responseHeaders, 'etag': entity.etag, 'vary': 'accept-encoding' };
+  const headersWithValidator: OutgoingHttpHeaders = { ...responseHeaders, etag: entity.etag, vary: 'accept-encoding' };
   const bodyLength = typeof entity.body === 'string' ? Buffer.byteLength(entity.body) : entity.body.length;
   if (bodyLength >= GZIP_MIN_BYTES && acceptsGzip(requestHeaders)) {
     entity.gzip ??= gzipSync(entity.body);
@@ -130,10 +130,24 @@ type ServerOptions = {
    * Mount the server under a URL sub-path (e.g. `damo` → served at `/damo/`).
    * Incoming paths are stripped of the prefix before file lookup and proxy
    * matching, so `proxy` keys must be written WITHOUT the base (use `/api`, not
-   * `/damo/api`). Defaults to root.
+   * `/damo/api`). Defaults to root. A reverse proxy can instead announce the
+   * prefix per request with the `X-Forwarded-Prefix` header, which overrides
+   * this option for that request — so the same server works unprefixed on
+   * localhost and prefixed behind the proxy at the same time.
    */
   base?: string;
 };
+
+// A mount prefix normalized to `/prefix` shape — from the `base` option or from
+// a reverse proxy's per-request `X-Forwarded-Prefix` header. Null when the value
+// is absent, empty, or not a plain path (guards emitted URLs and cache keys
+// against garbage header values).
+function normalizeBasePrefix(value: string | string[] | undefined): string | null {
+  const singleValue = Array.isArray(value) ? value[0] : value;
+  const normalized = singleValue?.replace(/^\/+|\/+$/g, '');
+  if (!normalized || !/^[\w\-./]{1,200}$/.test(normalized)) return null;
+  return `/${normalized}`;
+}
 
 function checkBasicAuth(authorizationHeader: string | string[] | undefined, expectedHeader: string): boolean {
   const header = Array.isArray(authorizationHeader) ? authorizationHeader[0] : authorizationHeader;
@@ -276,9 +290,7 @@ export class Server {
     // request paths are stripped of the `/damo` prefix before file lookup, and
     // resolved bare-specifier imports are emitted as `/damo/...` so the browser
     // requests them back under the same prefix instead of the origin root.
-    const normalizedBase = base.replace(/^\/+|\/+$/g, '');
-    const basePrefix = normalizedBase ? `/${normalizedBase}` : '';
-    const servedRoot = normalizedBase ? `/${normalizedBase}/` : '/';
+    const configuredBasePrefix = normalizeBasePrefix(base) ?? '';
 
     // Pre-parse proxy URLs once; used by the HTTP proxy and both WebSocket proxy paths.
     const proxyEntries = Object.entries(proxy).map(([proxyPath, target]) => ({
@@ -327,7 +339,7 @@ export class Server {
       return stats ? stats.mtimeMs : -1;
     }
 
-    async function getImportMap(htmlContent: string, pageServedPath: string, pageFilePath: string): Promise<ImportMap> {
+    async function getImportMap(htmlContent: string, pageServedPath: string, pageFilePath: string, servedRoot: string): Promise<ImportMap> {
       const cached = importMapCache.get(pageServedPath);
       if (cached) {
         const versionChecks = await Promise.all(
@@ -416,6 +428,12 @@ export class Server {
       const requestRange = headers[constants.HTTP2_HEADER_RANGE];
       const fetchDest = headers['sec-fetch-dest'];
       const requestPathString = typeof requestPath === 'string' ? requestPath : requestPath?.[0];
+
+      // The effective mount prefix for THIS request: what the reverse proxy in
+      // front announced, or the configured base. Everything the response embeds
+      // (import map, live-reload path, rewritten specifiers) derives from it.
+      const basePrefix = normalizeBasePrefix(headers['x-forwarded-prefix']) ?? configuredBasePrefix;
+      const servedRoot = basePrefix ? `${basePrefix}/` : '/';
 
       // Strip the mount prefix (e.g. `/damo`) so file serving and proxy matching
       // work off the origin root. `/damo` and `/damo/` both collapse to `/` → the
@@ -778,7 +796,7 @@ export class Server {
           });
           if (resolveModules) {
             const pageServedPath = `${servedRoot.slice(0, -1)}${filePath.slice(rootPath.length)}`;
-            const importMap = await getImportMap(fileContent, pageServedPath, responseFilePath);
+            const importMap = await getImportMap(fileContent, pageServedPath, responseFilePath, servedRoot);
             if (Object.keys(importMap.imports).length) {
               const importMapScript = `<script type="importmap">${JSON.stringify(importMap)}</script>`;
               // The map must precede every module script; fall back to
@@ -831,7 +849,10 @@ export class Server {
           sendCachedBody(stream, headers, responseHeaders, { body: fileContent, etag: contentEtag(fileContent) });
         }
         else if (sourceFilePath?.endsWith('.ts')) {
-          const entry = await cachedResponse(sourceFilePath, await stat(sourceFilePath), async () => {
+          // Rewritten bodies embed servedRoot, so the cache key carries it too —
+          // otherwise a prefixed and an unprefixed request for the same file
+          // would serve each other's variant.
+          const entry = await cachedResponse(`${servedRoot}\0${sourceFilePath}`, await stat(sourceFilePath), async () => {
             const fileContent = await readFile(sourceFilePath, {
               encoding: 'utf-8',
             });
@@ -848,7 +869,7 @@ export class Server {
         // body would corrupt it, and module scripts are never range-requested.
         else if (resolveModules && !requestRange && (fileExtension === '.js' || fileExtension === '.mjs')) {
           const modulePath = decodeURIComponent(responseFilePath);
-          const entry = await cachedResponse(modulePath, await stat(modulePath), async () => {
+          const entry = await cachedResponse(`${servedRoot}\0${modulePath}`, await stat(modulePath), async () => {
             const fileContent = await readFile(modulePath, { encoding: 'utf-8' });
             return rewriteModuleSpecifiers(fileContent, modulePath, servedRoot);
           });
@@ -910,8 +931,10 @@ export class Server {
      */
     this.http2SecureServer.on('upgrade', (request, socket, head) => {
       const requestPath = request.url || '';
-      // Strip the mount prefix (mirrors the stream handler) so proxy rules match
-      // and the upstream target receives the un-prefixed path under a base.
+      // Strip the mount prefix (mirrors the stream handler, forwarded prefix
+      // included) so proxy rules match and the upstream target receives the
+      // un-prefixed path under a base.
+      const basePrefix = normalizeBasePrefix(request.headers['x-forwarded-prefix']) ?? configuredBasePrefix;
       const strippedPath = stripBasePrefix(requestPath, basePrefix);
 
       if (expectedAuthHeader && !checkBasicAuth(request.headers['authorization'], expectedAuthHeader)) {
@@ -981,7 +1004,7 @@ export class Server {
     this.http2SecureServer.listen(serverPort);
 
     for (const [index, address] of addresses.entries()) {
-      const url = `https://${address}:${serverPort}${basePrefix}/${path}`;
+      const url = `https://${address}:${serverPort}${configuredBasePrefix}/${path}`;
       console.log(url);
       if (index !== 0) {
         console.log(await QRCode.toString(url, { type: 'terminal', small: true }));


### PR DESCRIPTION
Todo #68 (lib half; pairs with the playground gateway PR that announces the prefix).

A reverse proxy that mounts the server under a sub-path can now announce that prefix per request with the de-facto standard `X-Forwarded-Prefix` header — no `--base` needed. The effective prefix is resolved per request (header value, else configured `--base`) and threaded through path stripping, the import map, module specifier rewriting, and the live-reload path. Generated-response cache keys carry the served root, so prefixed and unprefixed variants of the same file are cached separately. The same server instance works unprefixed on `localhost:<n>/` and prefixed behind a proxy simultaneously.

- Header values are validated to a plain-path shape with bounded length; anything else falls back to the configured base, guarding emitted URLs and cache keys against garbage values.
- No new options or configuration — the header just works; `--base` behavior is unchanged for headerless requests (byte-identical output).
- Tests: prefix stripping + prefixed live-reload path, unprefixed requests untouched, specifier rewriting under the prefix with cache-variant separation (9/9 passing; lint and tsc clean).
- Verified end to end against a real gateway: a page requested with the header gets a prefixed import map and live-reload URL while plain requests stay unprefixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4FwvFQop5gG1oG9dWiTHX