### PR TITLE
One doc source per package

### DIFF
--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,48 +1,30 @@
 # @damienmortini/server — agent notes
 
-## No build step needed — the server transpiles TypeScript on the fly
+What the server does — [TypeScript served from `src/` behind the `dist/` URL][source]
+and the [injected import map][import-map] that lets browser code import installed
+packages by bare name — is documented in [README.md](./README.md), along with every
+CLI flag. Read it there; do not restate it here. The implementation lives in
+`src/server.ts` (request pipeline) and `src/module-resolution.ts` (resolution,
+import-map generation, dist→src mapping).
 
-This dev server serves TypeScript source as browser-ready JavaScript at request
-time. **Do not run a build to see source changes in the browser.**
+## Working on code this server serves
 
-How it works (`src/server.ts` — request pipeline; `src/module-resolution.ts` —
-resolution, import-map generation, dist→src mapping):
-
-- A request for `<package>/dist/<path>.js` is resolved to `<package>/src/<path>.ts`.
-  When that source file exists it is served instead of the built file — the
-  source always wins, so a stale `dist/` on disk is never served.
-- The `.ts` source has its types stripped with `node:module`'s
-  `stripTypeScriptTypes` and served otherwise untouched — module bodies are
-  never rewritten.
-- With `--resolve-modules`, the server crawls each HTML page's module graph and
-  injects a generated `<script type="importmap">`, so the browser resolves bare
-  specifiers (`@scope/pkg`) itself. Each bare import is resolved from the
-  importing module's own location (Node semantics, so pnpm-style nested
-  node_modules work) and canonicalized so every package maps to exactly one
-  URL — browsers deduplicate modules by URL. Bare specifiers whose build output
-  is missing are resolved through the package's `package.json`, so an unbuilt
-  dependency still maps and serves.
-- The map also lists every installed package name (import maps have no
-  fallback for unmapped bare specifiers); names the crawl did not reach point
-  at the reserved `/@resolve/<specifier>` route, which resolves the specifier
-  server-side **at import time** and answers with a re-export shim. That makes
-  computed dynamic imports work — `import('@damo/' + name)` or any installed
-  package name — while staying fully lazy.
-
-Practical consequences:
-
-- HTML can keep pointing `<script src=".../dist/element/index.js">` at the built
-  path. That is intentional and works without ever running a build — the server
-  serves the live `src/element/index.ts`.
-- Edit `src/*.ts` and reload; there is no build to run and no `dist/` to refresh.
-- Run the server with `--resolve-modules` so bare (`@scope/pkg`) imports work in
-  the browser via the injected import map. Relative imports must carry real
-  extensions (`./x.js`) — they are standard browser ESM and pass through as-is.
+- **Never run a build to see a source change in the browser.** Edit the `.ts`
+  source and reload the page.
+- **Leave HTML pointing at the built `dist/` path.** That is deliberate, not a
+  bug to fix — the rewrite is keyed on it.
+- Run the server with `--resolve-modules`, or bare (`@scope/pkg`) imports will
+  not resolve in the browser.
 
 ## Run
 
 ```
-node packages/server/src/bin/index.ts --resolve-modules --port <port> [--proxy /path http://target] [--auth user:pass]
+node packages/server/src/bin/index.ts --resolve-modules --port <port>
 ```
 
-The server is HTTP/2 with live reload (`watch` is always on).
+Run the bin's TypeScript entry point directly like this rather than `npx server`:
+the published bin points at `dist/bin/index.js`, which is not built in this
+checkout.
+
+[source]: ./README.md#typescript-served-from-source-no-build-step
+[import-map]: ./README.md#bare-specifiers-in-the-browser---resolve-modules

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -9,7 +9,10 @@ npx server [--path <path>] [--root <path>] [--base <base>] [--port <port>]
            [--verbose]
 ```
 
-`--watch` and `--proxy` may be repeated. Live reload is always on.
+`--watch` and `--proxy` may be repeated. Live reload is always on. The `--auth`
+credential can also be passed as `SERVER_AUTH` in the environment, which keeps it
+out of argv — and so out of `ps` and `/proc/<pid>/cmdline`; the flag wins when
+both are set.
 
 ## TypeScript served from source (no build step)
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -2,7 +2,28 @@
 
 Simple live reloading HTTP2 server for development
 
-`npx server [--path <path>] [--watch <path>] [--resolve-modules] [--verbose]`
+```
+npx server [--path <path>] [--root <path>] [--base <base>] [--port <port>]
+           [--watch <path>] [--watch-ignore <a,b>] [--proxy <path> <target>]
+           [--auth <user:pass>] [--external-certificate] [--resolve-modules]
+           [--verbose]
+```
+
+`--watch` and `--proxy` may be repeated. Live reload is always on.
+
+## TypeScript served from source (no build step)
+
+A request for `<package>/dist/<path>.js` is served from the sibling
+`<package>/src/<path>.ts` whenever that source exists — the source always wins,
+so a stale `dist/` on disk is never served. Types are stripped with
+`node:module`'s `stripTypeScriptTypes`; the module body is otherwise unchanged,
+apart from the bare-specifier rewrite described below.
+
+HTML can therefore keep pointing `<script src=".../dist/element/index.js">` at
+the published path: edit the `.ts` source and reload, with no build to run and
+no `dist/` to refresh. Keep pointing at that `dist/` URL rather than at `src/` —
+the mapping is keyed on `/dist/`, so a direct `.ts` request is served raw and
+the browser rejects it on MIME grounds.
 
 ## Bare specifiers in the browser (`--resolve-modules`)
 
@@ -16,6 +37,9 @@ import { Signal } from '@damienmortini/signal';
 
 const module = await import(`@damo/${name}-element/demo`); // computed names and subpaths too
 ```
+
+Only bare specifiers go through the map. Relative imports must carry real
+extensions (`./x.js`) — they are standard browser ESM and pass through as-is.
 
 ### What gets an entry
 
@@ -55,13 +79,13 @@ receive the page's import map — resolve their dependencies too.
 ### Interaction with the `dist/` → `src/` rewrite
 
 Map entries point at each package's **published** entry point (typically
-`dist/….js`), which is also what the browser requests. A request under `/dist/`
-is served from the sibling `/src/` file (`.js` → `.ts`), transpiled on the fly,
-whenever that source exists — so the URLs in the map stay stable while the code
-behind them is always the live source. A package whose `dist/` has never been
-built still gets a map entry: when Node resolution fails because the target
-file is absent, the specifier is resolved through the package's `package.json`
-without an existence check, and the request is then answered from `src/`.
+`dist/….js`), which is also what the browser requests, so the URLs in the map
+stay stable while the code behind them is always
+[the live source](#typescript-served-from-source-no-build-step). A package whose
+`dist/` has never been built still gets a map entry: when Node resolution fails
+because the target file is absent, the specifier is resolved through the
+package's `package.json` without an existence check, and the request is then
+answered from `src/`.
 
 ### Limits
 


### PR DESCRIPTION
`packages/server` carried both a `README.md` and an `AGENTS.md`, and each explained the same two capabilities — the `dist/` → `src/` rewrite and the injected import map. Two descriptions of one mechanism are free to drift, and they already had: the import map was documented only in `AGENTS.md`, which only agents read, which is why the damo gallery hand-rolled `package.json` resolution (todo #70) before the README section existed.

`README.md` is now the single source of truth for what the server does. `AGENTS.md` keeps only agent-workflow directives — don't build to see a change, leave HTML on the `dist/` path, pass `--resolve-modules` — plus reference links into the README sections and the repo-local run command.

`packages/server` is the only package in this repository with both files.

### Drift artefacts found while consolidating

Merging the two descriptions made three disagreements visible, fixed here:

- **`module bodies are never rewritten` was false.** With `--resolve-modules`, static bare imports inside served modules are rewritten server-side (`src/server.ts:879`) — README's own import-map section already said so, 50 lines below where the move would have planted the contradiction. Verified against the source and by serving a fixture.
- **The CLI synopsis was split.** `--port`, `--proxy` and `--auth` were documented only in `AGENTS.md`, and `--root` was referenced by README's *Limits* without ever being introduced. README's synopsis now lists every flag `src/bin/index.ts` implements.
- **A server behaviour was stranded in the agent file.** "Relative imports must carry real extensions" is an authoring rule, not agent workflow, and had never reached README.

One sentence was added to guard the instruction to keep HTML on the `dist/` path: the mapping is keyed on `/dist/` (`src/module-resolution.ts:63`), so a direct `.ts` request is served raw and the browser rejects it on MIME grounds.

Docs only — no code changes.

Closes #88.