### PR TITLE
Resolve /@resolve against the package real path

### DIFF
--- a/packages/server/src/module-resolution.test.ts
+++ b/packages/server/src/module-resolution.test.ts
@@ -1,0 +1,47 @@
+import { strictEqual } from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+describe('packages reached through a symlinked node_modules', () => {
+  // rootDirectory snapshots process.cwd() when this module loads, so each
+  // served root is probed in a process of its own. Under `--input-type=module`
+  // the probe's own import.meta.url is anchored in that working directory,
+  // which is exactly the importer a page served from there would have.
+  const probeSource = `
+    import { resolveSpecifierToServedPath } from ${JSON.stringify(join(import.meta.dirname, 'module-resolution.ts'))};
+    console.log(await resolveSpecifierToServedPath('@test/example', new URL(import.meta.url), '/'));
+  `;
+  let temporaryRoot: string;
+
+  before(async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'module-resolution-test-'));
+    // A repository linking its workspace package by a relative path, plus a
+    // scratch directory that borrows that whole node_modules through a symlink.
+    await mkdir(join(temporaryRoot, 'repository', 'packages', 'example', 'dist'), { recursive: true });
+    await mkdir(join(temporaryRoot, 'repository', 'node_modules', '@test'), { recursive: true });
+    await mkdir(join(temporaryRoot, 'scratch'), { recursive: true });
+    await writeFile(join(temporaryRoot, 'repository', 'packages', 'example', 'package.json'), '{"name":"@test/example","exports":"./dist/index.js"}');
+    await writeFile(join(temporaryRoot, 'repository', 'packages', 'example', 'dist', 'index.js'), 'export const value = 1;');
+    await symlink('../../packages/example', join(temporaryRoot, 'repository', 'node_modules', '@test', 'example'));
+    await symlink('../repository/node_modules', join(temporaryRoot, 'scratch', 'node_modules'));
+  });
+
+  after(async () => {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  });
+
+  function resolveExampleFrom(servedRootPath: string): string {
+    return execFileSync(process.execPath, ['--input-type=module', '--eval', probeSource], { cwd: servedRootPath, encoding: 'utf8' }).trim();
+  }
+
+  it('keeps a package whose link target leaves the served root on its node_modules path', () => {
+    strictEqual(resolveExampleFrom(join(temporaryRoot, 'scratch')), '/node_modules/@test/example/dist/index.js');
+  });
+
+  it('still collapses a link target that stays inside the served root', () => {
+    strictEqual(resolveExampleFrom(join(temporaryRoot, 'repository')), '/packages/example/dist/index.js');
+  });
+});

--- a/packages/server/src/module-resolution.ts
+++ b/packages/server/src/module-resolution.ts
@@ -9,7 +9,7 @@
  * Everything anchors on the process working directory (rootDirectory).
  */
 
-import { readdir, readFile, readlink, stat } from 'fs/promises';
+import { readdir, readFile, readlink, realpath, stat } from 'fs/promises';
 import { moduleResolve } from 'import-meta-resolve';
 import { dirname, extname, join, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -108,7 +108,13 @@ async function canonicalizeModuleUrl(moduleUrl: URL): Promise<URL> {
       continue;
     }
     symlinkHopBudget--;
-    const resolvedTargetPath = toPosixPath(resolve(dirname(candidatePath), symlinkTarget));
+    // Resolve the target against the directory that physically holds the link,
+    // not the walked-to path: an ancestor component may itself be a symlink
+    // leaving the served root (a scratch directory whose node_modules links
+    // into a repository), and a relative target rebased on that path would
+    // land back inside the root on a file that does not exist.
+    const realCurrentPath = await realpath(currentPath).catch(() => currentPath);
+    const resolvedTargetPath = toPosixPath(resolve(realCurrentPath, symlinkTarget));
     if (!`${resolvedTargetPath}/`.startsWith(rootDirectory)) {
       currentPath = candidatePath;
       continue;


### PR DESCRIPTION
Fixes todo #72.

`canonicalizeModuleUrl` walks the served root component by component (rather than calling `realpath`, which would escape the root) and resolved each symlink's target against the walked-to path. When an ancestor component was itself a symlink out of the served root — a scratch directory whose `node_modules` links into a repository — a relative target like `../../packages/example` got rebased onto the served root:

```
served root  /scratch/                 node_modules -> ../repository/node_modules
link         node_modules/@test/example -> ../../packages/example
resolved     /scratch/packages/example/dist/index.js   ← does not exist
```

So `/@resolve/<package>` answered with a shim pointing at a path the server then failed to stat, and workspace packages could only be served from the repository root itself.

The target is now resolved against the real path of the directory that physically holds the link, so the containment check compares physical paths on both sides. A link whose target leaves the root keeps its `node_modules` path (`/node_modules/@test/example/dist/index.js`), and an in-root workspace link still collapses onto one canonical URL as before.

## Verification

- New `src/module-resolution.test.ts` covers both directions; the first case fails on `main` and passes here. It probes each served root in its own process because `rootDirectory` snapshots `process.cwd()` at module load — filed as todo #106.
- End-to-end against a real server run from a scratch directory: `/@resolve/@test/pkg` → `export * from '/node_modules/@test/pkg/dist/index.js'`, and that path serves 200.
- `node --test src/*.test.ts` 12/12, eslint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqxXZR48L4CS32hVt2ETsL