### PR TITLE
Take the served root as a parameter

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -44,6 +44,10 @@ const module = await import(`@damo/${name}-element/demo`); // computed names and
 Only bare specifiers go through the map. Relative imports must carry real
 extensions (`./x.js`) — they are standard browser ESM and pass through as-is.
 
+Resolution anchors on the served root (`--root`, defaulting to the working
+directory), so the tree the server serves is the tree it resolves against
+wherever the process itself was started from.
+
 ### What gets an entry
 
 The server crawls the page's module graph — the `<script type="module">` tags
@@ -95,8 +99,6 @@ answered from `src/`.
 
 ### Limits
 
-- Resolution anchors on the server's working directory, so run the server from
-  the root it serves (it warns when `--root` points elsewhere).
 - A module reached *only* through `/@resolve/` was never crawled, so package
   names visible solely from that module's own non-hoisted `node_modules` are
   not enumerated.

--- a/packages/server/src/module-resolution.test.ts
+++ b/packages/server/src/module-resolution.test.ts
@@ -1,19 +1,13 @@
 import { strictEqual } from 'node:assert';
-import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, before, describe, it } from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+import { ModuleResolver } from './module-resolution.ts';
 
 describe('packages reached through a symlinked node_modules', () => {
-  // rootDirectory snapshots process.cwd() when this module loads, so each
-  // served root is probed in a process of its own. Under `--input-type=module`
-  // the probe's own import.meta.url is anchored in that working directory,
-  // which is exactly the importer a page served from there would have.
-  const probeSource = `
-    import { resolveSpecifierToServedPath } from ${JSON.stringify(join(import.meta.dirname, 'module-resolution.ts'))};
-    console.log(await resolveSpecifierToServedPath('@test/example', new URL(import.meta.url), '/'));
-  `;
   let temporaryRoot: string;
 
   before(async () => {
@@ -33,16 +27,17 @@ describe('packages reached through a symlinked node_modules', () => {
     await rm(temporaryRoot, { recursive: true, force: true });
   });
 
-  function resolveExampleFrom(servedRootPath: string): string {
-    return execFileSync(process.execPath, ['--input-type=module', '--eval', probeSource], { cwd: servedRootPath, encoding: 'utf8' }).trim();
+  // No importer: resolved from the served root, like a page sitting at it.
+  async function resolveExampleFrom(servedRootPath: string): Promise<string | undefined> {
+    return await new ModuleResolver(servedRootPath).resolveSpecifierToServedPath('@test/example', undefined, '/');
   }
 
-  it('keeps a package whose link target leaves the served root on its node_modules path', () => {
-    strictEqual(resolveExampleFrom(join(temporaryRoot, 'scratch')), '/node_modules/@test/example/dist/index.js');
+  it('keeps a package whose link target leaves the served root on its node_modules path', async () => {
+    strictEqual(await resolveExampleFrom(join(temporaryRoot, 'scratch')), '/node_modules/@test/example/dist/index.js');
   });
 
-  it('still collapses a link target that stays inside the served root', () => {
-    strictEqual(resolveExampleFrom(join(temporaryRoot, 'repository')), '/packages/example/dist/index.js');
+  it('still collapses a link target that stays inside the served root', async () => {
+    strictEqual(await resolveExampleFrom(join(temporaryRoot, 'repository')), '/packages/example/dist/index.js');
   });
 });
 
@@ -51,19 +46,14 @@ describe('packages reached through a submodule mounted outside the served root',
   // checkout: the same package is reachable directly and through a consumer's
   // own node_modules, and both must land on one URL or the module evaluates
   // twice and customElements.define() throws on the second run.
-  const probeSource = `
-    import { pathToFileURL } from 'node:url';
-    import { resolveSpecifierToServedPath } from ${JSON.stringify(join(import.meta.dirname, 'module-resolution.ts'))};
-    const [specifier, importerPath] = process.argv.slice(-2);
-    console.log(await resolveSpecifierToServedPath(specifier, pathToFileURL(importerPath), '/'));
-  `;
   let temporaryRoot: string;
-  let servedRootPath: string;
+  let resolver: ModuleResolver;
+  let consumerImporterPath: string;
 
   before(async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'module-resolution-mount-test-'));
     const repositoryPath = join(temporaryRoot, 'repository');
-    servedRootPath = join(temporaryRoot, 'playground');
+    const servedRootPath = join(temporaryRoot, 'playground');
     for (const packageName of ['example', 'consumer']) {
       await mkdir(join(repositoryPath, 'packages', packageName, 'dist'), { recursive: true });
       await writeFile(join(repositoryPath, 'packages', packageName, 'package.json'), `{"name":"@test/${packageName}","exports":"./dist/index.js"}`);
@@ -74,26 +64,47 @@ describe('packages reached through a submodule mounted outside the served root',
     await symlink('../../../example', join(repositoryPath, 'packages', 'consumer', 'node_modules', '@test', 'example'));
     await mkdir(join(servedRootPath, 'submodules'), { recursive: true });
     await symlink('../../repository', join(servedRootPath, 'submodules', 'repository'));
+    resolver = new ModuleResolver(servedRootPath);
+    consumerImporterPath = join(servedRootPath, 'submodules', 'repository', 'packages', 'consumer', 'dist', 'index.js');
   });
 
   after(async () => {
     await rm(temporaryRoot, { recursive: true, force: true });
   });
 
-  function resolveFrom(specifier: string, importerPath: string): string {
-    return execFileSync(process.execPath, ['--input-type=module', '--eval', probeSource, '--', specifier, importerPath], {
-      cwd: servedRootPath,
-      encoding: 'utf8',
-    }).trim();
-  }
-
-  it('serves a mounted checkout package under its submodule path', () => {
-    const importerPath = join(servedRootPath, 'submodules', 'repository', 'packages', 'consumer', 'dist', 'index.js');
-    strictEqual(resolveFrom('@test/consumer', importerPath), '/submodules/repository/packages/consumer/dist/index.js');
+  it('serves a mounted checkout package under its submodule path', async () => {
+    const servedPath = await resolver.resolveSpecifierToServedPath('@test/consumer', pathToFileURL(consumerImporterPath), '/');
+    strictEqual(servedPath, '/submodules/repository/packages/consumer/dist/index.js');
   });
 
-  it('collapses a dependency linked into a consumer onto that same mounted path', () => {
-    const importerPath = join(servedRootPath, 'submodules', 'repository', 'packages', 'consumer', 'dist', 'index.js');
-    strictEqual(resolveFrom('@test/example', importerPath), '/submodules/repository/packages/example/dist/index.js');
+  it('collapses a dependency linked into a consumer onto that same mounted path', async () => {
+    const servedPath = await resolver.resolveSpecifierToServedPath('@test/example', pathToFileURL(consumerImporterPath), '/');
+    strictEqual(servedPath, '/submodules/repository/packages/example/dist/index.js');
+  });
+});
+
+describe('a resolver anchored somewhere other than the process working directory', () => {
+  let temporaryRoot: string;
+  let resolver: ModuleResolver;
+
+  before(async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'module-resolution-root-test-'));
+    await mkdir(join(temporaryRoot, 'node_modules', 'demo-package'), { recursive: true });
+    await writeFile(join(temporaryRoot, 'node_modules', 'demo-package', 'package.json'), '{"name":"demo-package","main":"index.js"}');
+    await writeFile(join(temporaryRoot, 'node_modules', 'demo-package', 'index.js'), 'export const demo = true;');
+    await writeFile(join(temporaryRoot, 'module.js'), 'import { demo } from \'demo-package\';\n');
+    resolver = new ModuleResolver(temporaryRoot);
+  });
+
+  after(async () => {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  });
+
+  // The crawl reaches the page's module, maps its bare import and enumerates the
+  // installed packages — all of it against the fixture root rather than the cwd.
+  it('crawls a page into an import map rooted there', async () => {
+    const pageContent = '<html><head><script type="module" src="/module.js"></script></head></html>';
+    const { importMap } = await resolver.buildImportMap(pageContent, '/index.html', '/');
+    strictEqual(importMap.imports['demo-package'], '/node_modules/demo-package/index.js');
   });
 });

--- a/packages/server/src/module-resolution.ts
+++ b/packages/server/src/module-resolution.ts
@@ -6,7 +6,7 @@
  * unbuilt dist targets), canonicalization of symlinked paths onto one served
  * URL, the dist→src source mapping, and per-page import-map generation with
  * an installed-package enumeration backing the /@resolve/ on-demand route.
- * Everything anchors on the process working directory (rootDirectory).
+ * Everything anchors on the served root a ModuleResolver is constructed with.
  */
 
 import { readdir, readFile, readlink, realpath, stat } from 'fs/promises';
@@ -17,12 +17,9 @@ import { fileURLToPath, pathToFileURL } from 'url';
 const PACKAGE_EXPORT_CONDITIONS = ['browser', 'import', 'default', 'module', 'require'];
 const MODULE_RESOLVE_CONDITIONS = new Set(['module', 'import', 'default']);
 
-export function toPosixPath(path: string): string {
+function toPosixPath(path: string): string {
   return path.replaceAll(/\\/g, '/');
 }
-
-export const rootDirectory = toPosixPath(`${process.cwd()}/`);
-export const importMetaResolveParent = pathToFileURL(rootDirectory);
 
 export type PackageExportConditions = {
   [condition: string]: PackageExportValue;
@@ -77,72 +74,6 @@ export async function getSourceFilePath(filePath: string): Promise<string | unde
   }
 
   return undefined;
-}
-
-/**
- * Collapse a resolved module URL onto one canonical served URL.
- *
- * Browsers deduplicate ES modules by URL, so the same package reached through
- * different node_modules symlinks (pnpm links dependencies per consuming
- * package) would evaluate once per URL, and side effects like
- * customElements.define() would throw on the second evaluation. Resolve
- * symlinks component by component, like Node's --preserve-symlinks traversal,
- * keeping a link as-is when its target leaves the served root (e.g. a
- * submodule symlink to a sibling checkout) — a plain realpath would escape
- * the root there.
- */
-async function canonicalizeModuleUrl(moduleUrl: URL): Promise<URL> {
-  if (!moduleUrl.href.startsWith(importMetaResolveParent.href)) return moduleUrl;
-
-  const modulePath = toPosixPath(fileURLToPath(moduleUrl));
-  let remainingComponents = modulePath.slice(rootDirectory.length).split('/');
-  let currentPath = rootDirectory.slice(0, -1);
-  // The path a kept link sits at becomes the served location of everything
-  // under its target: `submodules/<name>` mounts a whole sibling checkout.
-  // Recording that pairing lets a deeper link into the same checkout — pnpm
-  // links every workspace dependency into its consumer's own node_modules, so
-  // one package is reachable through several such chains — collapse back onto
-  // the mounted path instead of staying a distinct URL and evaluating a second
-  // time. Without it only the outermost link is kept and nothing below it
-  // collapses, because every target down there leaves the root as well.
-  const adoptedMounts: Array<{ targetPath: string; servedPath: string }> = [];
-  // Bounds total symlink follows so link cycles cannot loop forever.
-  let symlinkHopBudget = 40;
-  while (remainingComponents.length > 0) {
-    const pathComponent = remainingComponents.shift()!;
-    const candidatePath = `${currentPath}/${pathComponent}`;
-    const symlinkTarget = symlinkHopBudget > 0 ? await readlink(candidatePath).catch(() => null) : null;
-    if (symlinkTarget === null) {
-      currentPath = candidatePath;
-      continue;
-    }
-    symlinkHopBudget--;
-    // Resolve the target against the directory that physically holds the link,
-    // not the walked-to path: an ancestor component may itself be a symlink
-    // leaving the served root (a scratch directory whose node_modules links
-    // into a repository), and a relative target rebased on that path would
-    // land back inside the root on a file that does not exist.
-    const realCurrentPath = await realpath(currentPath).catch(() => currentPath);
-    const resolvedTargetPath = toPosixPath(resolve(realCurrentPath, symlinkTarget));
-    let servedTargetPath = resolvedTargetPath;
-    if (!`${resolvedTargetPath}/`.startsWith(rootDirectory)) {
-      const mountedPath = servedPathWithinAdoptedMount(adoptedMounts, resolvedTargetPath);
-      if (mountedPath === undefined) adoptedMounts.push({ targetPath: resolvedTargetPath, servedPath: candidatePath });
-      // No mount covers the target, or this link is the mount itself — the walk
-      // has nowhere in-root to collapse onto, so keep the link as the URL.
-      if (mountedPath === undefined || mountedPath === candidatePath) {
-        currentPath = candidatePath;
-        continue;
-      }
-      servedTargetPath = mountedPath;
-    }
-    // Re-walk the in-root target from the served root so symlinks inside the
-    // adopted portion collapse too (e.g. a package reached through a nested
-    // submodule chain must land on the same URL as the direct submodule path).
-    remainingComponents = [...servedTargetPath.slice(rootDirectory.length).split('/'), ...remainingComponents];
-    currentPath = rootDirectory.slice(0, -1);
-  }
-  return pathToFileURL(currentPath);
 }
 
 /**
@@ -242,229 +173,321 @@ export function stripBasePrefix(path: string, basePrefix: string): string {
   return path;
 }
 
-// Map a browser-visible path to the file that would be served for it (a
-// `dist/*` request is answered from `src/*` when that source exists).
-export async function servedPathToSourcePath(servedPath: string, servedRoot: string): Promise<string> {
-  const diskPath = join(rootDirectory, stripBasePrefix(servedPath, servedRoot.slice(0, -1)));
-  return await getSourceFilePath(diskPath) ?? diskPath;
-}
-
-// Resolve a bare specifier from a parent module to its canonical served path,
-// or undefined when it cannot be resolved. The optional memo collapses repeat
-// canonicalizations of the same resolved URL within one request.
-export async function resolveSpecifierToServedPath(
-  specifier: string,
-  parentUrl: URL,
-  servedRoot: string,
-  canonicalServedPaths?: Map<string, Promise<string>>,
-): Promise<string | undefined> {
-  let moduleUrl: URL | undefined;
-  try {
-    moduleUrl = moduleResolve(specifier, parentUrl, MODULE_RESOLVE_CONDITIONS, true);
-  }
-  catch {
-    moduleUrl = await resolveUnbuiltSpecifier(specifier, parentUrl);
-  }
-  if (!moduleUrl) return undefined;
-
-  let servedPathPromise = canonicalServedPaths?.get(moduleUrl.href);
-  if (!servedPathPromise) {
-    // Arrow replacer so `$`-sequences in servedRoot are treated literally, not
-    // as String.replace special patterns ($&, $', …).
-    servedPathPromise = canonicalizeModuleUrl(moduleUrl)
-      .then(canonicalUrl => canonicalUrl.href.replace(importMetaResolveParent.href, () => servedRoot));
-    canonicalServedPaths?.set(moduleUrl.href, servedPathPromise);
-  }
-  return servedPathPromise;
-}
-
 /**
- * Rewrite the bare import specifiers in a served ES module to the canonical
- * served URLs they resolve to, so module resolution no longer depends on the
- * page's import map.
+ * Resolves modules against one served root.
  *
- * Import maps are never applied to Web Workers, so a module worker's bare
- * imports (e.g. `import { Signal } from '@damienmortini/signal'`) are
- * unresolvable through the map the way a main-thread module's are. Resolving
- * them in the module body — from the importer's own location, exactly like the
- * import-map crawl does — makes the same module load in a worker too. Relative
- * specifiers and full URLs (node:, data:, https:, …) are left untouched, and an
- * unresolvable bare specifier is left as-is so the browser error still names it.
+ * Every method anchors on the directory handed to the constructor, so a server
+ * started with a `rootPath` elsewhere resolves against the tree it actually
+ * serves. The per-call `servedRoot` argument is a different thing: the URL
+ * prefix that same tree is mounted under (`/` or `/mounted/app/`).
  */
-export async function rewriteModuleSpecifiers(
-  content: string,
-  importerSourceFilePath: string,
-  servedRoot: string,
-): Promise<string> {
-  const parentUrl = pathToFileURL(importerSourceFilePath);
-  const canonicalServedPaths = new Map<string, Promise<string>>();
-  const replacements = await Promise.all(
-    Array.from(content.matchAll(IMPORT_STATEMENT_REGEX), async (match) => {
-      const specifier = match[1];
-      // Skip relative specifiers and full URLs (node:, data:, https:, …).
-      if (RELATIVE_SPECIFIER_REGEX.test(specifier) || URL_SPECIFIER_REGEX.test(specifier)) return undefined;
-      const servedModulePath = await resolveSpecifierToServedPath(specifier, parentUrl, servedRoot, canonicalServedPaths);
-      if (!servedModulePath) return undefined;
-      // Splice only the specifier span, leaving the surrounding syntax intact.
-      const [start, end] = match.indices![1];
-      return { start, end, text: servedModulePath };
-    }),
-  );
-  // matchAll yields matches in source order, so the splices are already sorted.
-  const splices = replacements.filter(replacement => replacement !== undefined);
-  if (!splices.length) return content;
-  let result = '';
-  let cursor = 0;
-  for (const { start, end, text } of splices) {
-    result += content.slice(cursor, start) + text;
-    cursor = end;
-  }
-  return result + content.slice(cursor);
-}
+export class ModuleResolver {
+  /** The served root as an absolute posix path, without a trailing slash. */
+  readonly rootDirectory: string;
+  // The same root shaped for prefix tests and slices: as a path with a
+  // trailing slash, and as the directory URL every module URL inside it shares.
+  readonly #rootPrefix: string;
+  readonly #rootUrl: URL;
 
-/**
- * Build an import map for an HTML page by crawling its module graph.
- *
- * The injected map is what resolves bare specifiers in inline module scripts
- * and computed dynamic imports (via /@resolve/); static specifiers in served
- * module bodies are rewritten server-side by rewriteModuleSpecifiers instead,
- * which is the only mechanism that reaches workers — they never receive the
- * page's map. Each module's bare imports are
- * resolved from that module's own location like Node does — pnpm does not
- * hoist transitive dependencies of linked packages into the served root's
- * node_modules — and canonicalized so every package maps to exactly one URL
- * (browsers deduplicate modules by URL). If the same specifier resolves to a
- * different target from some importer, that resolution is scoped to the
- * importer's directory.
- */
-export async function buildImportMap(htmlContent: string, pageServedPath: string, servedRoot: string): Promise<ImportMapBuildResult> {
-  const importMap: ImportMap = { imports: {} };
-  const scopes: { [scopePrefix: string]: { [specifier: string]: string } } = {};
-  const visitedModulePaths = new Set<string>();
-  const visitedSourceDirectories = new Set<string>();
-  const dependencyPaths = new Set<string>();
-  // Many modules import the same package; canonicalize each resolved URL once.
-  const canonicalServedPaths = new Map<string, Promise<string>>();
-  // Crawl tasks run concurrently and append newly discovered modules as the
-  // graph unfolds; the drain loop below picks the additions up, so total crawl
-  // time tracks the longest import chain rather than the module count.
-  const crawlTasks: Promise<void>[] = [];
-
-  function enqueue(servedModulePath: string): void {
-    if (!CRAWLABLE_EXTENSIONS.has(extname(servedModulePath))) return;
-    if (visitedModulePaths.has(servedModulePath)) return;
-    visitedModulePaths.add(servedModulePath);
-    crawlTasks.push(crawlModule(servedModulePath));
+  constructor(rootPath: string) {
+    this.rootDirectory = toPosixPath(resolve(rootPath));
+    this.#rootPrefix = `${this.rootDirectory}/`;
+    this.#rootUrl = pathToFileURL(this.#rootPrefix);
   }
 
-  async function crawlModule(servedModulePath: string): Promise<void> {
-    const sourceFilePath = await servedPathToSourcePath(servedModulePath, servedRoot);
-    dependencyPaths.add(sourceFilePath);
-    visitedSourceDirectories.add(toPosixPath(dirname(sourceFilePath)));
-    const content = await readFile(sourceFilePath, { encoding: 'utf-8' }).catch(() => null);
-    if (content === null) return;
-    await collectImports(content, sourceFilePath, servedModulePath);
-  }
+  /**
+   * Collapse a resolved module URL onto one canonical served URL.
+   *
+   * Browsers deduplicate ES modules by URL, so the same package reached through
+   * different node_modules symlinks (pnpm links dependencies per consuming
+   * package) would evaluate once per URL, and side effects like
+   * customElements.define() would throw on the second evaluation. Resolve
+   * symlinks component by component, like Node's --preserve-symlinks traversal,
+   * keeping a link as-is when its target leaves the served root (e.g. a
+   * submodule symlink to a sibling checkout) — a plain realpath would escape
+   * the root there.
+   */
+  async #canonicalizeModuleUrl(moduleUrl: URL): Promise<URL> {
+    if (!moduleUrl.href.startsWith(this.#rootUrl.href)) return moduleUrl;
 
-  async function collectImports(content: string, importerSourceFilePath: string, importerServedPath: string): Promise<void> {
-    const importerBaseUrl = new URL(importerServedPath, SERVED_PATH_BASE);
-    const parentUrl = pathToFileURL(importerSourceFilePath);
-    await Promise.all(Array.from(content.matchAll(IMPORT_STATEMENT_REGEX), async (match) => {
-      const specifier = match[1];
-      // Skip full URLs (node:, data:, https:, …) — nothing to map or crawl.
-      if (URL_SPECIFIER_REGEX.test(specifier)) return;
-      if (RELATIVE_SPECIFIER_REGEX.test(specifier)) {
-        enqueue(new URL(specifier, importerBaseUrl).pathname);
-        return;
+    const modulePath = toPosixPath(fileURLToPath(moduleUrl));
+    let remainingComponents = modulePath.slice(this.#rootPrefix.length).split('/');
+    let currentPath = this.rootDirectory;
+    // The path a kept link sits at becomes the served location of everything
+    // under its target: `submodules/<name>` mounts a whole sibling checkout.
+    // Recording that pairing lets a deeper link into the same checkout — pnpm
+    // links every workspace dependency into its consumer's own node_modules, so
+    // one package is reachable through several such chains — collapse back onto
+    // the mounted path instead of staying a distinct URL and evaluating a second
+    // time. Without it only the outermost link is kept and nothing below it
+    // collapses, because every target down there leaves the root as well.
+    const adoptedMounts: Array<{ targetPath: string; servedPath: string }> = [];
+    // Bounds total symlink follows so link cycles cannot loop forever.
+    let symlinkHopBudget = 40;
+    while (remainingComponents.length > 0) {
+      const pathComponent = remainingComponents.shift()!;
+      const candidatePath = `${currentPath}/${pathComponent}`;
+      const symlinkTarget = symlinkHopBudget > 0 ? await readlink(candidatePath).catch(() => null) : null;
+      if (symlinkTarget === null) {
+        currentPath = candidatePath;
+        continue;
       }
-      const servedModulePath = await resolveSpecifierToServedPath(specifier, parentUrl, servedRoot, canonicalServedPaths);
-      // Leave an unresolvable specifier out of the map so the browser error
-      // names the real specifier.
-      if (!servedModulePath) {
-        console.log(`Unresolvable specifier "${specifier}" imported from ${importerServedPath}`);
-        return;
-      }
-      const mappedPath = importMap.imports[specifier];
-      if (mappedPath === undefined) {
-        importMap.imports[specifier] = servedModulePath;
-      }
-      else if (mappedPath !== servedModulePath) {
-        // Each importer records its own resolution, so whichever target wins
-        // the top-level entry, the others stay correct through their scope.
-        const scopePrefix = new URL('.', importerBaseUrl).pathname;
-        (scopes[scopePrefix] ??= {})[specifier] = servedModulePath;
-      }
-      enqueue(servedModulePath);
-    }));
-  }
-
-  const pageBaseUrl = new URL(pageServedPath, SERVED_PATH_BASE);
-  let hasModuleScripts = false;
-  let pageSourcePathPromise: Promise<string> | undefined;
-  for (const scriptMatch of htmlContent.matchAll(MODULE_SCRIPT_REGEX)) {
-    hasModuleScripts = true;
-    const sourceAttribute = scriptMatch[1].match(/\bsrc\s*=\s*["']([^"']+)["']/i);
-    if (sourceAttribute) {
-      enqueue(new URL(sourceAttribute[1], pageBaseUrl).pathname);
-    }
-    else if (scriptMatch[2]) {
-      const inlineScriptBody = scriptMatch[2];
-      pageSourcePathPromise ??= servedPathToSourcePath(pageServedPath, servedRoot);
-      crawlTasks.push(pageSourcePathPromise
-        .then(pageSourceFilePath => collectImports(inlineScriptBody, pageSourceFilePath, pageServedPath)));
-    }
-  }
-  if (!hasModuleScripts) return { importMap, dependencyPaths: [...dependencyPaths] };
-
-  // Elements pushed while awaiting are still visited: the array iterator
-  // re-checks the length on every step.
-  for (const crawlTask of crawlTasks) {
-    await crawlTask;
-  }
-
-  // Import maps have no fallback for unmapped bare specifiers — a dynamic
-  // import() of a computed name throws before any network request unless the
-  // name is a map key. So every package name installed along the crawled
-  // modules' node_modules chains gets an entry; names the crawl did not
-  // already map point at the /@resolve/ route, which resolves them
-  // server-side at import time. Intentional boundary: a module reached only
-  // through /@resolve/ was never crawled, so names visible solely from its
-  // own non-hoisted node_modules are not enumerated.
-  const pageSourceFilePath = await (pageSourcePathPromise ?? servedPathToSourcePath(pageServedPath, servedRoot));
-  dependencyPaths.add(pageSourceFilePath);
-  visitedSourceDirectories.add(toPosixPath(dirname(pageSourceFilePath)));
-  const nodeModulesDirectories = new Set<string>();
-  for (const sourceDirectory of visitedSourceDirectories) {
-    let currentDirectory = sourceDirectory;
-    while (`${currentDirectory}/`.startsWith(rootDirectory)) {
-      nodeModulesDirectories.add(`${currentDirectory}/node_modules`);
-      currentDirectory = dirname(currentDirectory);
-    }
-  }
-  const installedPackageNames = new Set<string>();
-  await Promise.all(Array.from(nodeModulesDirectories, async (nodeModulesDirectory) => {
-    const entryNames = await readdir(nodeModulesDirectory).catch((): string[] => []);
-    await Promise.all(entryNames.map(async (entryName) => {
-      if (entryName.startsWith('.')) return;
-      if (entryName.startsWith('@')) {
-        for (const scopedName of await readdir(`${nodeModulesDirectory}/${entryName}`).catch((): string[] => [])) {
-          if (!scopedName.startsWith('.')) installedPackageNames.add(`${entryName}/${scopedName}`);
+      symlinkHopBudget--;
+      // Resolve the target against the directory that physically holds the link,
+      // not the walked-to path: an ancestor component may itself be a symlink
+      // leaving the served root (a scratch directory whose node_modules links
+      // into a repository), and a relative target rebased on that path would
+      // land back inside the root on a file that does not exist.
+      const realCurrentPath = await realpath(currentPath).catch(() => currentPath);
+      const resolvedTargetPath = toPosixPath(resolve(realCurrentPath, symlinkTarget));
+      let servedTargetPath = resolvedTargetPath;
+      if (!`${resolvedTargetPath}/`.startsWith(this.#rootPrefix)) {
+        const mountedPath = servedPathWithinAdoptedMount(adoptedMounts, resolvedTargetPath);
+        if (mountedPath === undefined) adoptedMounts.push({ targetPath: resolvedTargetPath, servedPath: candidatePath });
+        // No mount covers the target, or this link is the mount itself — the walk
+        // has nowhere in-root to collapse onto, so keep the link as the URL.
+        if (mountedPath === undefined || mountedPath === candidatePath) {
+          currentPath = candidatePath;
+          continue;
         }
+        servedTargetPath = mountedPath;
       }
-      else {
-        installedPackageNames.add(entryName);
-      }
-    }));
-  }));
-  for (const packageName of installedPackageNames) {
-    importMap.imports[packageName] ??= `${servedRoot}@resolve/${packageName}`;
-    // Subpath imports (`package/sub`) route through the resolver too.
-    importMap.imports[`${packageName}/`] ??= `${servedRoot}@resolve/${packageName}/`;
-  }
-  for (const nodeModulesDirectory of nodeModulesDirectories) {
-    dependencyPaths.add(nodeModulesDirectory);
+      // Re-walk the in-root target from the served root so symlinks inside the
+      // adopted portion collapse too (e.g. a package reached through a nested
+      // submodule chain must land on the same URL as the direct submodule path).
+      remainingComponents = [...servedTargetPath.slice(this.#rootPrefix.length).split('/'), ...remainingComponents];
+      currentPath = this.rootDirectory;
+    }
+    return pathToFileURL(currentPath);
   }
 
-  if (Object.keys(scopes).length) importMap.scopes = scopes;
-  return { importMap, dependencyPaths: [...dependencyPaths] };
+  // Map a browser-visible path to the file that would be served for it (a
+  // `dist/*` request is answered from `src/*` when that source exists).
+  async servedPathToSourcePath(servedPath: string, servedRoot: string): Promise<string> {
+    const diskPath = join(this.rootDirectory, stripBasePrefix(servedPath, servedRoot.slice(0, -1)));
+    return await getSourceFilePath(diskPath) ?? diskPath;
+  }
+
+  // Resolve a bare specifier from a parent module to its canonical served path,
+  // or undefined when it cannot be resolved. A specifier with no page of its own
+  // to resolve from (the /@resolve/ route reached without a referer) passes no
+  // parent and is resolved from the served root. The optional memo collapses
+  // repeat canonicalizations of the same resolved URL within one request.
+  async resolveSpecifierToServedPath(
+    specifier: string,
+    parentUrl: URL | undefined,
+    servedRoot: string,
+    canonicalServedPaths?: Map<string, Promise<string>>,
+  ): Promise<string | undefined> {
+    const importerUrl = parentUrl ?? this.#rootUrl;
+    let moduleUrl: URL | undefined;
+    try {
+      moduleUrl = moduleResolve(specifier, importerUrl, MODULE_RESOLVE_CONDITIONS, true);
+    }
+    catch {
+      moduleUrl = await resolveUnbuiltSpecifier(specifier, importerUrl);
+    }
+    if (!moduleUrl) return undefined;
+
+    let servedPathPromise = canonicalServedPaths?.get(moduleUrl.href);
+    if (!servedPathPromise) {
+      // Arrow replacer so `$`-sequences in servedRoot are treated literally, not
+      // as String.replace special patterns ($&, $', …).
+      servedPathPromise = this.#canonicalizeModuleUrl(moduleUrl)
+        .then(canonicalUrl => canonicalUrl.href.replace(this.#rootUrl.href, () => servedRoot));
+      canonicalServedPaths?.set(moduleUrl.href, servedPathPromise);
+    }
+    return servedPathPromise;
+  }
+
+  /**
+   * Rewrite the bare import specifiers in a served ES module to the canonical
+   * served URLs they resolve to, so module resolution no longer depends on the
+   * page's import map.
+   *
+   * Import maps are never applied to Web Workers, so a module worker's bare
+   * imports (e.g. `import { Signal } from '@damienmortini/signal'`) are
+   * unresolvable through the map the way a main-thread module's are. Resolving
+   * them in the module body — from the importer's own location, exactly like the
+   * import-map crawl does — makes the same module load in a worker too. Relative
+   * specifiers and full URLs (node:, data:, https:, …) are left untouched, and an
+   * unresolvable bare specifier is left as-is so the browser error still names it.
+   */
+  async rewriteModuleSpecifiers(
+    content: string,
+    importerSourceFilePath: string,
+    servedRoot: string,
+  ): Promise<string> {
+    const parentUrl = pathToFileURL(importerSourceFilePath);
+    const canonicalServedPaths = new Map<string, Promise<string>>();
+    const replacements = await Promise.all(
+      Array.from(content.matchAll(IMPORT_STATEMENT_REGEX), async (match) => {
+        const specifier = match[1];
+        // Skip relative specifiers and full URLs (node:, data:, https:, …).
+        if (RELATIVE_SPECIFIER_REGEX.test(specifier) || URL_SPECIFIER_REGEX.test(specifier)) return undefined;
+        const servedModulePath = await this.resolveSpecifierToServedPath(specifier, parentUrl, servedRoot, canonicalServedPaths);
+        if (!servedModulePath) return undefined;
+        // Splice only the specifier span, leaving the surrounding syntax intact.
+        const [start, end] = match.indices![1];
+        return { start, end, text: servedModulePath };
+      }),
+    );
+    // matchAll yields matches in source order, so the splices are already sorted.
+    const splices = replacements.filter(replacement => replacement !== undefined);
+    if (!splices.length) return content;
+    let result = '';
+    let cursor = 0;
+    for (const { start, end, text } of splices) {
+      result += content.slice(cursor, start) + text;
+      cursor = end;
+    }
+    return result + content.slice(cursor);
+  }
+
+  /**
+   * Build an import map for an HTML page by crawling its module graph.
+   *
+   * The injected map is what resolves bare specifiers in inline module scripts
+   * and computed dynamic imports (via /@resolve/); static specifiers in served
+   * module bodies are rewritten server-side by rewriteModuleSpecifiers instead,
+   * which is the only mechanism that reaches workers — they never receive the
+   * page's map. Each module's bare imports are
+   * resolved from that module's own location like Node does — pnpm does not
+   * hoist transitive dependencies of linked packages into the served root's
+   * node_modules — and canonicalized so every package maps to exactly one URL
+   * (browsers deduplicate modules by URL). If the same specifier resolves to a
+   * different target from some importer, that resolution is scoped to the
+   * importer's directory.
+   */
+  async buildImportMap(htmlContent: string, pageServedPath: string, servedRoot: string): Promise<ImportMapBuildResult> {
+    const importMap: ImportMap = { imports: {} };
+    const scopes: { [scopePrefix: string]: { [specifier: string]: string } } = {};
+    const visitedModulePaths = new Set<string>();
+    const visitedSourceDirectories = new Set<string>();
+    const dependencyPaths = new Set<string>();
+    // Many modules import the same package; canonicalize each resolved URL once.
+    const canonicalServedPaths = new Map<string, Promise<string>>();
+    // Crawl tasks run concurrently and append newly discovered modules as the
+    // graph unfolds; the drain loop below picks the additions up, so total crawl
+    // time tracks the longest import chain rather than the module count.
+    const crawlTasks: Promise<void>[] = [];
+
+    const enqueue = (servedModulePath: string): void => {
+      if (!CRAWLABLE_EXTENSIONS.has(extname(servedModulePath))) return;
+      if (visitedModulePaths.has(servedModulePath)) return;
+      visitedModulePaths.add(servedModulePath);
+      crawlTasks.push(crawlModule(servedModulePath));
+    };
+
+    const crawlModule = async (servedModulePath: string): Promise<void> => {
+      const sourceFilePath = await this.servedPathToSourcePath(servedModulePath, servedRoot);
+      dependencyPaths.add(sourceFilePath);
+      visitedSourceDirectories.add(toPosixPath(dirname(sourceFilePath)));
+      const content = await readFile(sourceFilePath, { encoding: 'utf-8' }).catch(() => null);
+      if (content === null) return;
+      await collectImports(content, sourceFilePath, servedModulePath);
+    };
+
+    const collectImports = async (content: string, importerSourceFilePath: string, importerServedPath: string): Promise<void> => {
+      const importerBaseUrl = new URL(importerServedPath, SERVED_PATH_BASE);
+      const parentUrl = pathToFileURL(importerSourceFilePath);
+      await Promise.all(Array.from(content.matchAll(IMPORT_STATEMENT_REGEX), async (match) => {
+        const specifier = match[1];
+        // Skip full URLs (node:, data:, https:, …) — nothing to map or crawl.
+        if (URL_SPECIFIER_REGEX.test(specifier)) return;
+        if (RELATIVE_SPECIFIER_REGEX.test(specifier)) {
+          enqueue(new URL(specifier, importerBaseUrl).pathname);
+          return;
+        }
+        const servedModulePath = await this.resolveSpecifierToServedPath(specifier, parentUrl, servedRoot, canonicalServedPaths);
+        // Leave an unresolvable specifier out of the map so the browser error
+        // names the real specifier.
+        if (!servedModulePath) {
+          console.log(`Unresolvable specifier "${specifier}" imported from ${importerServedPath}`);
+          return;
+        }
+        const mappedPath = importMap.imports[specifier];
+        if (mappedPath === undefined) {
+          importMap.imports[specifier] = servedModulePath;
+        }
+        else if (mappedPath !== servedModulePath) {
+          // Each importer records its own resolution, so whichever target wins
+          // the top-level entry, the others stay correct through their scope.
+          const scopePrefix = new URL('.', importerBaseUrl).pathname;
+          (scopes[scopePrefix] ??= {})[specifier] = servedModulePath;
+        }
+        enqueue(servedModulePath);
+      }));
+    };
+
+    const pageBaseUrl = new URL(pageServedPath, SERVED_PATH_BASE);
+    let hasModuleScripts = false;
+    let pageSourcePathPromise: Promise<string> | undefined;
+    for (const scriptMatch of htmlContent.matchAll(MODULE_SCRIPT_REGEX)) {
+      hasModuleScripts = true;
+      const sourceAttribute = scriptMatch[1].match(/\bsrc\s*=\s*["']([^"']+)["']/i);
+      if (sourceAttribute) {
+        enqueue(new URL(sourceAttribute[1], pageBaseUrl).pathname);
+      }
+      else if (scriptMatch[2]) {
+        const inlineScriptBody = scriptMatch[2];
+        pageSourcePathPromise ??= this.servedPathToSourcePath(pageServedPath, servedRoot);
+        crawlTasks.push(pageSourcePathPromise
+          .then(pageSourceFilePath => collectImports(inlineScriptBody, pageSourceFilePath, pageServedPath)));
+      }
+    }
+    if (!hasModuleScripts) return { importMap, dependencyPaths: [...dependencyPaths] };
+
+    // Elements pushed while awaiting are still visited: the array iterator
+    // re-checks the length on every step.
+    for (const crawlTask of crawlTasks) {
+      await crawlTask;
+    }
+
+    // Import maps have no fallback for unmapped bare specifiers — a dynamic
+    // import() of a computed name throws before any network request unless the
+    // name is a map key. So every package name installed along the crawled
+    // modules' node_modules chains gets an entry; names the crawl did not
+    // already map point at the /@resolve/ route, which resolves them
+    // server-side at import time. Intentional boundary: a module reached only
+    // through /@resolve/ was never crawled, so names visible solely from its
+    // own non-hoisted node_modules are not enumerated.
+    const pageSourceFilePath = await (pageSourcePathPromise ?? this.servedPathToSourcePath(pageServedPath, servedRoot));
+    dependencyPaths.add(pageSourceFilePath);
+    visitedSourceDirectories.add(toPosixPath(dirname(pageSourceFilePath)));
+    const nodeModulesDirectories = new Set<string>();
+    for (const sourceDirectory of visitedSourceDirectories) {
+      let currentDirectory = sourceDirectory;
+      while (`${currentDirectory}/`.startsWith(this.#rootPrefix)) {
+        nodeModulesDirectories.add(`${currentDirectory}/node_modules`);
+        currentDirectory = dirname(currentDirectory);
+      }
+    }
+    const installedPackageNames = new Set<string>();
+    await Promise.all(Array.from(nodeModulesDirectories, async (nodeModulesDirectory) => {
+      const entryNames = await readdir(nodeModulesDirectory).catch((): string[] => []);
+      await Promise.all(entryNames.map(async (entryName) => {
+        if (entryName.startsWith('.')) return;
+        if (entryName.startsWith('@')) {
+          for (const scopedName of await readdir(`${nodeModulesDirectory}/${entryName}`).catch((): string[] => [])) {
+            if (!scopedName.startsWith('.')) installedPackageNames.add(`${entryName}/${scopedName}`);
+          }
+        }
+        else {
+          installedPackageNames.add(entryName);
+        }
+      }));
+    }));
+    for (const packageName of installedPackageNames) {
+      importMap.imports[packageName] ??= `${servedRoot}@resolve/${packageName}`;
+      // Subpath imports (`package/sub`) route through the resolver too.
+      importMap.imports[`${packageName}/`] ??= `${servedRoot}@resolve/${packageName}/`;
+    }
+    for (const nodeModulesDirectory of nodeModulesDirectories) {
+      dependencyPaths.add(nodeModulesDirectory);
+    }
+
+    if (Object.keys(scopes).length) importMap.scopes = scopes;
+    return { importMap, dependencyPaths: [...dependencyPaths] };
+  }
 }

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -163,18 +163,22 @@ describe('live-reload client script', () => {
 });
 
 describe('forwarded prefix', () => {
-  // Module resolution anchors on the process working directory, so the fixture
-  // with its own node_modules lives inside it — a tmpdir root would leave bare
-  // specifiers unresolvable and the rewrite untestable.
   let fixturePath: string;
   let server: Server;
   let basedServer: Server;
 
   before(async () => {
-    fixturePath = await mkdtemp('server-test-fixture-');
+    fixturePath = await mkdtemp(join(tmpdir(), 'server-test-fixture-'));
     await mkdir(join(fixturePath, 'node_modules', 'demo-package'), { recursive: true });
     await writeFile(join(fixturePath, 'node_modules', 'demo-package', 'package.json'), '{"name":"demo-package","main":"index.js"}');
     await writeFile(join(fixturePath, 'node_modules', 'demo-package', 'index.js'), 'export const demo = true;');
+    // A package whose `./sub` entry has no directory on disk, so requesting its
+    // package.json exercises the synthesized one.
+    await mkdir(join(fixturePath, 'node_modules', 'subpath-package'), { recursive: true });
+    await writeFile(
+      join(fixturePath, 'node_modules', 'subpath-package', 'package.json'),
+      '{"name":"subpath-package","type":"module","exports":{"./sub":"./dist/sub.js"}}',
+    );
     await writeFile(join(fixturePath, 'module.js'), 'import { demo } from \'demo-package\';\nconsole.log(demo);');
     await writeFile(join(fixturePath, 'index.html'), '<html><head><title>test</title></head><body></body></html>');
     server = new Server({ rootPath: fixturePath, watch: true, resolveModules: true, port: 9201 });
@@ -208,11 +212,18 @@ describe('forwarded prefix', () => {
   });
 
   it('rewrites module specifiers under the announced prefix without poisoning the unprefixed variant', async () => {
+    // The paths are rooted at the served root, not at the working directory the
+    // test process happens to run from.
     const unprefixed = await fetchBody(boundPort(server), '/module.js');
-    ok(unprefixed.includes(`'/${fixturePath}/node_modules/demo-package/index.js'`), `expected an unprefixed rewritten specifier, got: ${unprefixed}`);
+    ok(unprefixed.includes('\'/node_modules/demo-package/index.js\''), `expected an unprefixed rewritten specifier, got: ${unprefixed}`);
     const prefixed = await fetchBody(boundPort(server), '/mounted/app/module.js', { 'x-forwarded-prefix': '/mounted/app' });
-    ok(prefixed.includes(`'/mounted/app/${fixturePath}/node_modules/demo-package/index.js'`), `expected a rewritten specifier under the prefix, got: ${prefixed}`);
+    ok(prefixed.includes('\'/mounted/app/node_modules/demo-package/index.js\''), `expected a rewritten specifier under the prefix, got: ${prefixed}`);
     const unprefixedAgain = await fetchBody(boundPort(server), '/module.js');
     strictEqual(unprefixedAgain, unprefixed, 'expected the prefixed variant to be cached separately');
+  });
+
+  it('synthesizes a package.json for a subpath export under a root outside the working directory', async () => {
+    const body = await fetchBody(boundPort(server), '/node_modules/subpath-package/sub/package.json');
+    strictEqual(JSON.parse(body).main, '../dist/sub.js');
   });
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -10,7 +10,7 @@ import { request as httpsRequest } from 'https';
 import mimeTypes from 'mime-types';
 import { connect as netConnect, isIP } from 'net';
 import { hostname, networkInterfaces as getNetworkInterfaces } from 'os';
-import { extname, join, resolve } from 'path';
+import { extname, join } from 'path';
 import QRCode from 'qrcode';
 import { generate as generateSelfSignedCertificate } from 'selfsigned';
 import { pathToFileURL } from 'url';
@@ -18,18 +18,12 @@ import { v5 as uuidv5 } from 'uuid';
 import { gzipSync } from 'zlib';
 
 import {
-  buildImportMap,
   getSourceFilePath,
   type ImportMap,
-  importMetaResolveParent,
+  ModuleResolver,
   type PackageJson,
   resolvePackageExportPath,
-  resolveSpecifierToServedPath,
-  rewriteModuleSpecifiers,
-  rootDirectory,
-  servedPathToSourcePath,
   stripBasePrefix,
-  toPosixPath,
 } from './module-resolution.ts';
 
 const HOP_BY_HOP_HEADERS = new Set(['connection', 'upgrade', 'keep-alive', 'transfer-encoding']);
@@ -279,13 +273,11 @@ export class Server {
     auth,
     base = '',
   }: ServerOptions = {}): Promise<void> {
-    // The module-resolution subsystem (import map crawl, /@resolve/) anchors on
-    // the process working directory, while file serving anchors on rootPath —
-    // with a rootPath elsewhere the server would serve one tree and resolve
-    // modules against another.
-    if (resolveModules && `${toPosixPath(resolve(rootPath))}/` !== rootDirectory) {
-      console.warn(`resolveModules resolves modules from the working directory (${rootDirectory}), not from rootPath "${rootPath}" — run the server from the served root to keep them aligned.`);
-    }
+    // File serving and the module-resolution subsystem (import map crawl,
+    // /@resolve/) share one absolute root, so they always agree on which tree is
+    // being served, wherever the process itself happens to be running from.
+    const moduleResolver = new ModuleResolver(rootPath);
+    const { rootDirectory } = moduleResolver;
 
     const expectedAuthHeader = auth ? `Basic ${Buffer.from(auth).toString('base64')}` : null;
 
@@ -359,7 +351,7 @@ export class Server {
           return cached.importMap;
         }
       }
-      const { importMap, dependencyPaths } = await buildImportMap(htmlContent, pageServedPath, servedRoot);
+      const { importMap, dependencyPaths } = await moduleResolver.buildImportMap(htmlContent, pageServedPath, servedRoot);
       // The page file itself is always a dependency: editing its module scripts
       // must invalidate the map even when no crawled module changed.
       const dependencyVersions = new Map(await Promise.all(
@@ -589,7 +581,7 @@ export class Server {
       if (servedPath === '/.well-known/appspecific/com.chrome.devtools.json') {
         const workspaceConfig = {
           workspace: {
-            root: rootDirectory.slice(0, -1),
+            root: rootDirectory,
             uuid: uuidv5(rootDirectory, uuidv5.URL),
           },
         };
@@ -687,10 +679,12 @@ export class Server {
         if (resolveModules && resolverMatch) {
           const specifier = decodeURIComponent(resolverMatch.groups!.specifier);
           const refererUrl = URL.parse(String(headers['referer'] ?? ''));
+          // No referer means no page to resolve from; the resolver falls back
+          // to the served root.
           const parentUrl = refererUrl
-            ? pathToFileURL(await servedPathToSourcePath(refererUrl.pathname, servedRoot))
-            : importMetaResolveParent;
-          const servedModulePath = await resolveSpecifierToServedPath(specifier, parentUrl, servedRoot);
+            ? pathToFileURL(await moduleResolver.servedPathToSourcePath(refererUrl.pathname, servedRoot))
+            : undefined;
+          const servedModulePath = await moduleResolver.resolveSpecifierToServedPath(specifier, parentUrl, servedRoot);
           if (!servedModulePath) {
             stream.respond({ ':status': constants.HTTP_STATUS_NOT_FOUND });
             stream.end();
@@ -699,7 +693,7 @@ export class Server {
           // `export * from` does not forward a default export; add it only
           // when the target module declares one.
           let shim = `export * from '${servedModulePath}';\n`;
-          const targetSource = await readFile(await servedPathToSourcePath(servedModulePath, servedRoot), { encoding: 'utf-8' }).catch(() => '');
+          const targetSource = await readFile(await moduleResolver.servedPathToSourcePath(servedModulePath, servedRoot), { encoding: 'utf-8' }).catch(() => '');
           if (/\bexport\s+default\b|\bexport\s*\{[^}]*\bdefault\b/.test(targetSource)) {
             shim += `export { default } from '${servedModulePath}';\n`;
           }
@@ -712,7 +706,7 @@ export class Server {
           return;
         }
 
-        let filePath = `${rootPath}${requestFilePath}`;
+        let filePath = `${rootDirectory}${requestFilePath}`;
 
         /**
          * Synthesize a package.json for subpath exports that don't have a real file on disk.
@@ -721,9 +715,10 @@ export class Server {
          * fetching `<package>/<subpath>/package.json` and importing its `main` — damo's
          * index.html lazy-loads subpath entries like `@damo/playground-element/demo` this way.
          */
-        const virtualPackageJsonMatch = filePath
-          .replace(/^\.?\//, '')
-          .match(/^node_modules\/(?<packageName>@[^/]+\/[^/]+|[^/]+)\/(?<subPath>.+)\/package\.json$/);
+        // Matched on the request path: it always starts at the served root,
+        // whereas the disk path is prefixed with the root's own directory names.
+        const virtualPackageJsonMatch = requestFilePath
+          .match(/^\/node_modules\/(?<packageName>@[^/]+\/[^/]+|[^/]+)\/(?<subPath>.+)\/package\.json$/);
         if (virtualPackageJsonMatch) {
           const { packageName, subPath } = virtualPackageJsonMatch.groups!;
           const physicalStats = await stat(filePath).catch(() => null);
@@ -731,7 +726,7 @@ export class Server {
 
           if (!physicalExists) {
             try {
-              const mainPackageJsonPath = join(rootPath, 'node_modules', packageName, 'package.json');
+              const mainPackageJsonPath = join(rootDirectory, 'node_modules', packageName, 'package.json');
               const mainPackageJson = JSON.parse(await readFile(mainPackageJsonPath, 'utf-8')) as PackageJson;
               const exportValue = mainPackageJson.exports?.[`./${subPath}`];
               const exportPath = resolvePackageExportPath(exportValue);
@@ -764,7 +759,7 @@ export class Server {
          * Rewrite to root if url isn't a file and doesn't exist
          */
         if (!/\.[^/]*$/.test(filePath) && !(await stat(filePath).catch(() => null))) {
-          filePath = `${rootPath}/`;
+          filePath = `${rootDirectory}/`;
         }
 
         const sourceFilePath = await getSourceFilePath(filePath);
@@ -812,7 +807,7 @@ export class Server {
             encoding: 'utf-8',
           });
           if (resolveModules) {
-            const pageServedPath = `${servedRoot.slice(0, -1)}${filePath.slice(rootPath.length)}`;
+            const pageServedPath = `${servedRoot.slice(0, -1)}${filePath.slice(rootDirectory.length)}`;
             const importMap = await getImportMap(fileContent, pageServedPath, responseFilePath, servedRoot);
             if (Object.keys(importMap.imports).length) {
               const importMapScript = `<script type="importmap">${JSON.stringify(importMap)}</script>`;
@@ -876,7 +871,7 @@ export class Server {
             const javaScript = stripTypeScriptTypes(fileContent);
             // Rewrite bare imports to resolved URLs so module workers, which never
             // receive the page's import map, can still resolve their dependencies.
-            return resolveModules ? await rewriteModuleSpecifiers(javaScript, sourceFilePath, servedRoot) : javaScript;
+            return resolveModules ? await moduleResolver.rewriteModuleSpecifiers(javaScript, sourceFilePath, servedRoot) : javaScript;
           });
           sendCachedBody(stream, headers, responseHeaders, entry);
         }
@@ -888,7 +883,7 @@ export class Server {
           const modulePath = decodeURIComponent(responseFilePath);
           const entry = await cachedResponse(`${servedRoot}\0${modulePath}`, await stat(modulePath), async () => {
             const fileContent = await readFile(modulePath, { encoding: 'utf-8' });
-            return rewriteModuleSpecifiers(fileContent, modulePath, servedRoot);
+            return moduleResolver.rewriteModuleSpecifiers(fileContent, modulePath, servedRoot);
           });
           sendCachedBody(stream, headers, responseHeaders, entry);
         }


### PR DESCRIPTION
`module-resolution.ts` snapshotted `rootDirectory` from `process.cwd()` at module load, so nothing that resolved modules could be pointed at another root. A `Server` built with `rootPath` served one tree and resolved modules against another, and `server.ts` could only warn about the mismatch (`server.ts:286`).

## What changed

The module-level snapshot becomes a `ModuleResolver` constructed with the served root. `Server` builds one from its own `rootPath`, so file serving and module resolution anchor on the same absolute root — and the "run the server from the served root" warning is deleted rather than documented as a limit.

Two consequences worth review attention:

- **File paths are now absolute**, so the virtual `package.json` match moves from the disk path to the request path (which always starts at the served root). The old `filePath.replace(/^\.?\//, '')` only parsed correctly while `rootPath` was `.`.
- **A specifier with no page of its own** (the `/@resolve/` route reached without a referer) now passes no parent instead of the caller reaching for the resolver's root URL, keeping the anchoring rule inside the resolver.

## Tests

The resolution tests drop their per-root child processes (`node --input-type=module --eval` with a `cwd`) and construct a resolver per fixture directory in-process — the subsystem is now reachable from a plain unit test. The server fixture moves out of the working directory into `tmpdir()`, which is what the cwd anchoring had prevented.

New coverage for the virtual `package.json` re-anchor; confirmed it fails against the old form.

16 tests pass, eslint and `tsc --noEmit` clean. Also verified end-to-end by running the real server from an unrelated working directory with `--root` elsewhere: import map, module rewrite, both `/@resolve/` paths and the DevTools workspace root all resolve against the served tree.

Closes todo #106.