### PR TITLE
Port worktree-setup to lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "eslint packages && pnpm -r run test",
     "update": "pnpm i",
     "upgrade": "syncpack update && syncpack fix && pnpm i",
-    "version": "lerna version"
+    "version": "lerna version",
+    "worktree:setup": "node script/worktree-setup.ts"
   },
   "dependencies": {
     "es-module-shims": "^2.8.1"

--- a/script/worktree-setup.ts
+++ b/script/worktree-setup.ts
@@ -18,11 +18,17 @@ import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-const worktreeRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+// Both roots are resolved before anything compares them: `git rev-parse` resolves symlinks
+// while `git worktree list` echoes each path as it was registered, and one directory
+// spelled two ways would clear the guard below as "this is a linked worktree" — pointing
+// the mirroring at the primary's own node_modules, which materialize deletes before it
+// reads. That directory is shared with every other worktree and costs a full install.
+const worktreeRoot = await fs.realpath(execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim());
 // git lists the main worktree — the one holding the installed node_modules — first.
-const primaryRoot = execFileSync('git', ['worktree', 'list', '--porcelain'], { encoding: 'utf8' })
+const primaryRoot = await fs.realpath(execFileSync('git', ['worktree', 'list', '--porcelain'], { encoding: 'utf8' })
   .split('\n')[0]
-  .replace(/^worktree /, '');
+  .replace(/^worktree /, '')
+  .trim());
 
 if (worktreeRoot === primaryRoot) {
   console.error(`${worktreeRoot} is the primary checkout — run this from inside a linked worktree (its node_modules comes from \`pnpm install\`).`);

--- a/script/worktree-setup.ts
+++ b/script/worktree-setup.ts
@@ -1,0 +1,92 @@
+// A fresh git worktree has no node_modules at all, so nothing resolves in it — not a
+// workspace package, not a third-party dependency, not a local binary. `pnpm install`
+// would fix that, but it re-runs every postinstall build and rewrites the lockfile for a
+// checkout that is usually thrown away within the hour; this mirrors the primary
+// checkout's node_modules in about a second instead. Every installed package is symlinked
+// across, while scope directories (`@damienmortini`, `@types`, …) and `.bin` are recreated
+// with their original relative links, so workspace specifiers resolve to the worktree's
+// own packages rather than the primary checkout's.
+//
+// The link tree covers everything that reads source directly: eslint across the repo, and
+// a package's own tests and typecheck — `packages/server` runs both off `src`. A sibling
+// imported by name resolves to its `dist`, which a fresh worktree has not built, so
+// typechecking or running code that crosses package boundaries needs `pnpm run build`
+// first. Run this from inside the worktree.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const worktreeRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+// git lists the main worktree — the one holding the installed node_modules — first.
+const primaryRoot = execFileSync('git', ['worktree', 'list', '--porcelain'], { encoding: 'utf8' })
+  .split('\n')[0]
+  .replace(/^worktree /, '');
+
+if (worktreeRoot === primaryRoot) {
+  console.error(`${worktreeRoot} is the primary checkout — run this from inside a linked worktree (its node_modules comes from \`pnpm install\`).`);
+  process.exit(1);
+}
+
+/**
+ * Recreate `source` at `target` as a tree of symlinks: relative links are copied
+ * verbatim so they resolve inside the worktree, everything else points at the primary.
+ * Removing `target` first keeps re-runs idempotent.
+ */
+async function materialize(source: string, target: string): Promise<void> {
+  await fs.rm(target, { recursive: true, force: true });
+  await fs.mkdir(target, { recursive: true });
+
+  for (const entry of await fs.readdir(source, { withFileTypes: true })) {
+    // pnpm's own bookkeeping (`.modules.yaml`, `.pnpm`, …) describes the primary checkout.
+    // Linking it would let an install run here write back into the shared checkout, so
+    // leave it out and let pnpm treat this worktree as the uninstalled tree it is.
+    if (entry.name.startsWith('.') && entry.name !== '.bin') continue;
+
+    const sourcePath = path.join(source, entry.name);
+    const targetPath = path.join(target, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      await fs.symlink(await fs.readlink(sourcePath), targetPath);
+    }
+    else if (entry.isDirectory() && (entry.name.startsWith('@') || entry.name === '.bin')) {
+      await materialize(sourcePath, targetPath);
+    }
+    else {
+      await fs.symlink(sourcePath, targetPath);
+    }
+  }
+}
+
+/**
+ * node_modules directories nested under `directory`, relative to the primary checkout.
+ * Never descends into one: a match found deeper inside would be materialized through a
+ * symlink and write into the primary checkout.
+ */
+async function nestedModulesDirectories(directory: string): Promise<string[]> {
+  const directories: string[] = [];
+
+  for (const entry of await fs.readdir(path.join(primaryRoot, directory), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const child = path.join(directory, entry.name);
+    if (entry.name === 'node_modules') directories.push(child);
+    else directories.push(...await nestedModulesDirectories(child));
+  }
+
+  return directories;
+}
+
+await materialize(path.join(primaryRoot, 'node_modules'), path.join(worktreeRoot, 'node_modules'));
+
+// pnpm nests what it cannot hoist — a version conflict, and the workspace links between
+// sibling packages, which are relative and so follow the worktree's own sources across.
+const nestedModules = (await nestedModulesDirectories('packages'))
+  // A branch that deletes a package must not get its node_modules recreated underneath.
+  .filter(directory => existsSync(path.join(worktreeRoot, path.dirname(directory))));
+
+for (const directory of nestedModules) {
+  await materialize(path.join(primaryRoot, directory), path.join(worktreeRoot, directory));
+}
+
+console.log(`Linked ${nestedModules.length + 1} node_modules directories from ${primaryRoot}. Worktree ready.`);


### PR DESCRIPTION
A fresh `~/lib` worktree has no `node_modules`, so eslint, tsc and `node --test` all die before doing any work. Until now the workaround was symlinking the primary checkout's hoisted `node_modules` by hand (see todo #72). damo removed this friction in todo #69 and playground in todo #78 — lib was the third repo still missing it.

`script/worktree-setup.ts`, exposed as `npm run worktree:setup`, mirrors the primary checkout's `node_modules` as a symlink tree in ~1 second. Installed packages are symlinked across; scope directories (`@damienmortini`, `@types`, …) and `.bin` are recreated with their original **relative** links, so workspace specifiers resolve to the worktree's own packages rather than the primary's. lib nests 29 `packages/**/node_modules` directories that pnpm could not hoist, so those are mirrored too — 30 directories in total.

## Deliberate differences from the damo port

- **No build step.** The todo scoped this to a dependencies-only materialization, and that holds: `packages/server` runs its tests and typecheck off `src`.
- **No by-name linking of workspace packages into root `node_modules`.** damo does this; lib must not. Root `node_modules/@damienmortini/server` is a real directory holding the **published 1.0.89**, while `packages/server` is 1.0.90 — pnpm deliberately did not link the workspace copy, and blanket linking would silently change what `npm start` / `npm run serve` execute. `eslint-config` and `typescript-config` are already relative symlinks, so they follow the worktree across for free.
- **pnpm's installer state is skipped.** damo's and playground's versions symlink `.modules.yaml`, `.package-map.json`, `.pnpm/` and `.pnpm-workspace-state-v1.json` back into the primary, which would let a `pnpm install` run in a worktree write into the checkout every parallel agent shares. Filed as todo #128 for those two repos.

## Verification

Run against a genuinely empty worktree (all `node_modules` deleted first):

| Check | Primary `~/lib` | This worktree |
|---|---|---|
| `packages/server` `npm test` | — | **14/14 pass** |
| `packages/server` `tsc --noEmit` | exit 0 | **exit 0** |
| `npm run lint` (repo-wide) | 532 errors | **532 errors — identical** |

The 532 eslint errors are a pre-existing baseline on `main`, unchanged by this PR. `npx eslint script/worktree-setup.ts` is clean.

Also verified: re-running is idempotent; running it from a primary checkout exits 1 without touching `node_modules` (tested in a throwaway repo, not against the shared checkout); and the shared `~/lib` checkout is left untouched — clean `git status`, all 534 entries and 7 dot-state files intact.

## Known limitation

Repo-wide `tsc --noEmit` reports **19 more errors** in a fresh worktree than in the primary (1157 vs 1138). All 19 trace to `@damienmortini/math`, `@damienmortini/signal` and `@damienmortini/gesture-observer`: a sibling imported by name resolves to its `dist`, which a fresh worktree has not built. `pnpm run build` closes the gap. This is documented in the script's header rather than fixed, since the todo scoped out the build — and repo-wide tsc is 1138 errors deep on `main` regardless, so it is not a green gate today.

Worth noting for anyone comparing typecheck output: `@damienmortini/typescript-config` sets `incremental: true`, so a stale root `tsconfig.tsbuildinfo` makes `tsc --noEmit` report *fewer* errors than a cache-free run. Filed as todo #129.

Closes todo #107.