### PR TITLE
Resolve the eslint ignore file from the config, not the cwd

### DIFF
--- a/packages/eslint-config/find-ignore-files.js
+++ b/packages/eslint-config/find-ignore-files.js
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/**
+ * Collect the `.gitignore` files governing a directory, outermost first, the way git
+ * stacks them. ESLint can be invoked from anywhere — a workspace package that was just
+ * touched, for instance — so no ignore file can be assumed to sit in the working
+ * directory, and a package's own `.gitignore` must not shadow the repository's.
+ * @param {string} startDirectory Absolute directory to search upwards from.
+ * @returns {string[]} Absolute ignore file paths, empty when the repository has none.
+ */
+export function findIgnoreFiles(startDirectory) {
+  const ignoreFiles = [];
+  for (let directory = startDirectory; ; directory = dirname(directory)) {
+    const ignoreFile = join(directory, '.gitignore');
+    if (existsSync(ignoreFile)) ignoreFiles.unshift(ignoreFile);
+    // Stop at the repository root: a parent repository's patterns govern its own files,
+    // not this one's. A filesystem root ends a checkout that has no repository at all.
+    if (existsSync(join(directory, '.git')) || dirname(directory) === directory) return ignoreFiles;
+  }
+}

--- a/packages/eslint-config/find-ignore-files.test.js
+++ b/packages/eslint-config/find-ignore-files.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+
+import { findIgnoreFiles } from './find-ignore-files.js';
+
+/**
+ * Build a throwaway directory tree under a fresh temporary root, removed when the test
+ * ends. A path ending in `/` becomes a directory, anything else an empty file; missing
+ * parent directories are created either way.
+ * @param {import('node:test').TestContext} testContext Test the tree belongs to.
+ * @param {string[]} paths Paths to create, relative to the temporary root.
+ * @returns {string} Absolute path of the temporary root.
+ */
+function createTree(testContext, paths) {
+  const root = mkdtempSync(join(tmpdir(), 'find-ignore-files-'));
+  testContext.after(() => rmSync(root, { recursive: true, force: true }));
+  for (const path of paths) {
+    const absolutePath = join(root, path);
+    if (path.endsWith('/')) {
+      mkdirSync(absolutePath, { recursive: true });
+    }
+    else {
+      mkdirSync(dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, '');
+    }
+  }
+  return root;
+}
+
+test('stacks every ignore file from the repository root down, outermost first', (testContext) => {
+  const root = createTree(testContext, ['.git/', '.gitignore', 'packages/server/.gitignore']);
+
+  assert.deepEqual(findIgnoreFiles(join(root, 'packages/server')), [
+    join(root, '.gitignore'),
+    join(root, 'packages/server/.gitignore'),
+  ]);
+});
+
+test('keeps the repository ignore file for a package that has none of its own', (testContext) => {
+  const root = createTree(testContext, ['.git/', '.gitignore', 'packages/core/']);
+
+  assert.deepEqual(findIgnoreFiles(join(root, 'packages/core')), [join(root, '.gitignore')]);
+});
+
+test('stops at the repository root so a parent repository never leaks its patterns in', (testContext) => {
+  const root = createTree(testContext, ['.gitignore', 'nested/.git/', 'nested/.gitignore', 'nested/src/']);
+
+  assert.deepEqual(findIgnoreFiles(join(root, 'nested/src')), [join(root, 'nested/.gitignore')]);
+});
+
+test('stops at a linked worktree, whose `.git` is a file rather than a directory', (testContext) => {
+  const root = createTree(testContext, ['.gitignore', 'worktree/.git', 'worktree/.gitignore', 'worktree/src/']);
+
+  assert.deepEqual(findIgnoreFiles(join(root, 'worktree/src')), [join(root, 'worktree/.gitignore')]);
+});
+
+test('returns nothing when the repository has no ignore file, rather than throwing', (testContext) => {
+  const root = createTree(testContext, ['.git/', 'src/']);
+
+  assert.deepEqual(findIgnoreFiles(join(root, 'src')), []);
+});

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,6 +1,3 @@
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-
 import pluginJs from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
 import { includeIgnoreFile } from 'eslint/config';
@@ -8,24 +5,7 @@ import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
-/**
- * Collect the `.gitignore` files governing a directory, outermost first, the way git
- * stacks them. ESLint can be invoked from anywhere — a workspace package that was just
- * touched, for instance — so no ignore file can be assumed to sit in the working
- * directory, and a package's own `.gitignore` must not shadow the repository's.
- * @param {string} startDirectory Absolute directory to search upwards from.
- * @returns {string[]} Absolute ignore file paths, empty when the repository has none.
- */
-function findIgnoreFiles(startDirectory) {
-  const ignoreFiles = [];
-  for (let directory = startDirectory; ; directory = dirname(directory)) {
-    const ignoreFile = join(directory, '.gitignore');
-    if (existsSync(ignoreFile)) ignoreFiles.unshift(ignoreFile);
-    // Stop at the repository root: a parent repository's patterns govern its own files,
-    // not this one's. A filesystem root ends a checkout that has no repository at all.
-    if (existsSync(join(directory, '.git')) || dirname(directory) === directory) return ignoreFiles;
-  }
-}
+import { findIgnoreFiles } from './find-ignore-files.js';
 
 export default [
   // `gitignoreResolution` anchors each file's patterns to its own directory, so they keep

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,17 +1,36 @@
-import { includeIgnoreFile } from '@eslint/compat';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
 import pluginJs from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
+import { includeIgnoreFile } from 'eslint/config';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
-import { join } from 'path';
 import tseslint from 'typescript-eslint';
 
-const gitignorePath = join(process.cwd(), '.gitignore');
+/**
+ * Collect the `.gitignore` files governing a directory, outermost first, the way git
+ * stacks them. ESLint can be invoked from anywhere — a workspace package that was just
+ * touched, for instance — so no ignore file can be assumed to sit in the working
+ * directory, and a package's own `.gitignore` must not shadow the repository's.
+ * @param {string} startDirectory Absolute directory to search upwards from.
+ * @returns {string[]} Absolute ignore file paths, empty when the repository has none.
+ */
+function findIgnoreFiles(startDirectory) {
+  const ignoreFiles = [];
+  for (let directory = startDirectory; ; directory = dirname(directory)) {
+    const ignoreFile = join(directory, '.gitignore');
+    if (existsSync(ignoreFile)) ignoreFiles.unshift(ignoreFile);
+    // Stop at the repository root: a parent repository's patterns govern its own files,
+    // not this one's. A filesystem root ends a checkout that has no repository at all.
+    if (existsSync(join(directory, '.git')) || dirname(directory) === directory) return ignoreFiles;
+  }
+}
 
 export default [
-  {
-    ignores: includeIgnoreFile(gitignorePath).ignores, // Has to be done like this while https://github.com/eslint/eslint/issues/18723 is fixed.
-  },
+  // `gitignoreResolution` anchors each file's patterns to its own directory, so they keep
+  // meaning what git means by them however deep ESLint was invoked.
+  ...includeIgnoreFile(findIgnoreFiles(process.cwd()), { gitignoreResolution: true }),
   stylistic.configs.customize({
     semi: true,
   }),

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@eslint/compat": "^2.1.0",
     "@eslint/js": "10.0.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "eslint": "10.5.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,6 +14,9 @@
   "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
+  "scripts": {
+    "test": "node --test *.test.js"
+  },
   "dependencies": {
     "@eslint/js": "10.0.1",
     "@stylistic/eslint-plugin": "^5.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,9 +266,6 @@ importers:
 
   packages/eslint-config:
     dependencies:
-      '@eslint/compat':
-        specifier: ^2.1.0
-        version: 2.1.0(eslint@10.5.0(supports-color@7.2.0))
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.5.0(supports-color@7.2.0))
@@ -686,15 +683,6 @@ packages:
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/compat@2.1.0':
-    resolution: {integrity: sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^8.40 || 9 || 10
-    peerDependenciesMeta:
-      eslint:
-        optional: true
 
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
@@ -3972,12 +3960,6 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/compat@2.1.0(eslint@10.5.0(supports-color@7.2.0))':
-    dependencies:
-      '@eslint/core': 1.2.1
-    optionalDependencies:
-      eslint: 10.5.0(supports-color@7.2.0)
 
   '@eslint/config-array@0.23.5(supports-color@7.2.0)':
     dependencies:


### PR DESCRIPTION
## Problem

`packages/eslint-config/index.js` computed `join(process.cwd(), '.gitignore')`, so the shared config silently assumed eslint is always invoked from a repository root. Linting one package — the natural thing to do after touching one — died before any rule ran:

```
$ npx eslint src        # from inside a workspace package
Error: ENOENT: no such file or directory, open '<package>/.gitignore'
    at includeIgnoreFile (@eslint/compat)
    at packages/eslint-config/index.js:13
```

Nothing in the error named the config as the cause, and it meant no workspace package could ever carry its own `lint` script.

## Change

- Walk up from the working directory collecting **every** `.gitignore` from the repository root down, the way git stacks them.
- Stop at the directory holding `.git`, so a parent repository's patterns never leak into a nested checkout.
- A checkout with no ignore file contributes no ignores rather than crashing.
- `includeIgnoreFile` now comes from `eslint/config` (`@eslint/config-helpers`) with `gitignoreResolution: true`, which anchors each file's patterns to its own directory. That is the first-class mechanism for this, and the reason the eslint#18723 `.ignores`-unwrapping workaround can go — retiring the last use of `@eslint/compat`.

Collecting the whole chain rather than just the nearest file matters in this repo specifically: `packages/router`, `packages/server` and `packages/package-builder` each have their own `.gitignore`, and nearest-wins would silently drop the root's `.nx`, `dist` and `lerna-debug.log` patterns for any run started inside one of them.

## Verification

| Check | Result |
|---|---|
| Full-repo `eslint .` vs. pre-change baseline | identical — 253 files, 532 errors, 0 warnings |
| `eslint util` from `packages/core` (the ENOENT crash) | rules run |
| From `packages/server`: root-only pattern (`.nx`) | still ignored — root patterns survive |
| From `packages/server`: package-only pattern (`/certificates`) | ignored — nested patterns apply |
| Gitignored path (`dist/`) probed from root and from a package | ignored identically from both |
| Checkout with no `.gitignore` anywhere | lints instead of crashing |
| Nested repo whose parent has a `.gitignore` | parent's patterns correctly excluded |
| `npx eslint src test` in `damo`'s `playground-element` (the reported case) | exit 0 |

Unblocks #108, which wants a package-local `lint` script for playground.

## Note on the lockfile

`@eslint/compat` is removed from `pnpm-lock.yaml` by hand rather than by regenerating: `origin/main`'s lockfile is already out of date with `packages/typescript-config/package.json` (missing `@webgpu/types@^0.1.71`, so `pnpm install --frozen-lockfile` already fails there), and regenerating would have swept that unrelated drift into this diff. The hand edit was verified byte-identical to `pnpm install --lockfile-only`'s output apart from that pre-existing drift. **The lockfile drift on main is worth a separate fix.**

## Deferred — worth a follow-up decision

Three of the four `/simplify` reviewers independently argued the *deepest* fix is to stop the package discovering the ignore file at all: let each consumer's `eslint.config.js` pass `includeIgnoreFile(join(import.meta.dirname, '.gitignore'), { gitignoreResolution: true })`, since `import.meta.dirname` is the one genuinely stable anchor and is also eslint's default `basePath`. That would delete the walk, the `process.cwd()` read and the `.git` probe, and satisfies the "glue lives on the glue side" rule more cleanly.

It is not done here because it is a breaking change for every consuming repository, and #119 explicitly prescribes the in-config walk. Flagging it as the design call it is.