### PR TITLE
Bring lib pnpm-lock.yaml back in step with its packages

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,0 +1,15 @@
+# Every day-to-day command here installs non-frozen, silently repairing a lockfile that
+# has fallen out of step with a package.json; only deploy installs frozen, and by then the
+# commit is on main. This runs the full install a consumer runs, on the pull request.
+name: Lockfile
+
+on:
+  pull_request:
+
+jobs:
+  frozen-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@damienmortini/eslint-config": "0.0.32",
     "@damienmortini/server": "workspace:^",
-    "@damienmortini/typescript-config": "0.0.18",
+    "@damienmortini/typescript-config": "workspace:^",
     "eslint": "10.5.0",
     "fast-glob": "^3.3.3",
     "jsdoc": "^4.0.5",

--- a/packages/package-builder/package.json
+++ b/packages/package-builder/package.json
@@ -25,9 +25,6 @@
     "fast-glob": "^3.3.3",
     "typescript": "6.0.3"
   },
-  "devDependencies": {
-    "@damienmortini/typescript-config": "0.0.18"
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: workspace:^
         version: link:packages/server
       '@damienmortini/typescript-config':
-        specifier: 0.0.18
+        specifier: workspace:^
         version: link:packages/typescript-config
       eslint:
         specifier: 10.5.0
@@ -373,10 +373,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-    devDependencies:
-      '@damienmortini/typescript-config':
-        specifier: 0.0.18
-        version: link:../typescript-config
 
   packages/router:
     devDependencies:
@@ -463,6 +459,9 @@ importers:
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.4
+      '@webgpu/types':
+        specifier: ^0.1.71
+        version: 0.1.71
 
   packages/webgl:
     dependencies:
@@ -1342,6 +1341,9 @@ packages:
 
   '@vue/shared@3.5.38':
     resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
+
+  '@webgpu/types@0.1.71':
+    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -4753,6 +4755,8 @@ snapshots:
       '@vue/shared': 3.5.38
 
   '@vue/shared@3.5.38': {}
+
+  '@webgpu/types@0.1.71': {}
 
   '@yarnpkg/lockfile@1.1.0': {}
 


### PR DESCRIPTION
`pnpm install --frozen-lockfile` fails on lib main:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with packages/typescript-config/package.json
  * 1 dependencies were added: @webgpu/types@^0.1.71
```

`@webgpu/types` was restored to `packages/typescript-config` by e2cd234c without an install, so the lockfile never got the entry. Nothing here installs frozen except `deploy.yml`, which runs after the merge to main, so the drift stayed invisible from inside and surfaced from outside — damo's new lint and typecheck job (#122) checks lib out beside it and installs it.

## Regenerating alone would have made it worse

`packages/typescript-config` is at **0.0.19**; the root and `packages/package-builder` pinned the exact **0.0.18**. `linkWorkspacePackages: true` links only while the pin satisfies the local version, so a plain regeneration rewrote both importers from `link:packages/typescript-config` to the **published 0.0.18 tarball** — the version whose dropped WebGPU typings, `target: ESNext` and `skipLibCheck` e2cd234c had just fixed. 0.0.19 is not on npm, so those two would have silently compiled against the regression this repo had already repaired.

So the specifiers are fixed too:

- **root** → `workspace:^`, matching `"@damienmortini/server": "workspace:^"` on the line above it. The root is `private: true` — exactly the case #54 established.
- **`packages/package-builder`** → the entry is **removed**. Its `tsconfig.json` extends `../../tsconfig.json`, and it is the only one of the ten packages that do so which also declared the dependency. Verified with `tsc --showConfig` from the package: the resolved config still carries `@webgpu/types` and `skipLibCheck` from the local 0.0.19. Dropping it also keeps the `workspace:` protocol out of a published manifest.

## Did anything else drift?

Scanned all **65** workspace manifests field-by-field against the lockfile importers (`dependencies`, `devDependencies`, `optionalDependencies`, both directions). `typescript-config` was the only one. The `packages/animation` case in the todo had already been repaired on main.

## The CI gate

`.github/workflows/lockfile.yml` runs the same **full** frozen install a consumer runs, on the pull request. Deliberately not `--lockfile-only`: the cheap form catches this exact error in ~2s, but the full install is what damo's job actually does to lib, so it also proves every locked resolution is fetchable before the merge rather than after.

**What it does not catch:** a frozen install compares specifier *strings*, so an importer recording `version: 0.0.18` instead of `link:` passes green while installing a stale published copy. **35 intra-repo specifiers are still exact pins with zero margin** — each de-links the next time its package is bumped, and `syncpack fix` (which `npm run upgrade` runs) is what manufactures them. Filed as **todo #181**; `packages/graph`'s deliberate `^1.0.90` and `publish.yml`'s non-frozen install are covered there.

## Verification

- `pnpm install --frozen-lockfile` → exits 0
- `pnpm run build` → all packages build, including `package-builder`
- `pnpm run lint` → 532 errors, **identical on untouched main** (pre-existing, unrelated)