### PR TITLE
Publish worktree setup as a shared package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@damienmortini/eslint-config": "0.0.32",
     "@damienmortini/server": "workspace:^",
     "@damienmortini/typescript-config": "workspace:^",
+    "@damienmortini/worktree-setup": "workspace:*",
     "eslint": "10.5.0",
     "fast-glob": "^3.3.3",
     "jsdoc": "^4.0.5",

--- a/packages/worktree-setup/README.md
+++ b/packages/worktree-setup/README.md
@@ -1,0 +1,126 @@
+# @damienmortini/worktree-setup
+
+Link a fresh git worktree against the primary checkout's installed dependencies.
+
+A fresh worktree has no `node_modules` at all, so nothing resolves in it. `pnpm install`
+is not the fix: these repositories reach their siblings through `submodules/*` symlinks, so
+an install inside a worktree writes outside it and into the checkouts other agents are
+working in. `setupWorktree` mirrors the primary checkout's `node_modules` instead — every
+installed package symlinked across, scope directories and `.bin` recreated with their
+original relative links, so workspace specifiers resolve to the worktree's own packages
+rather than the primary's, including packages the branch adds.
+
+`~/lib`, `~/damo`, `~/playground` and `~/graph` each carried their own copy of this, and the
+copies drifted: a fix found in one had to be re-derived in the other three. This is the one
+copy. What differs between the repositories is passed in, so the package itself stays dumb
+about who is calling it.
+
+## Why there is no `bin`
+
+While the command runs from inside the worktree — which is what `npm run worktree:setup`
+does, and what the `damo-worktree` skill documents — a `bin` cannot be the entry point: the
+tree it would have to resolve through is the one this creates. So each repository keeps a
+small `script/worktree-setup.ts` that finds the primary checkout with git and imports this
+package from *its* `node_modules`. That bootstrap is the irreducible part; everything above
+it lives here.
+
+## Using it from a repository
+
+`package.json`:
+
+```json
+{
+  "scripts": { "worktree:setup": "node script/worktree-setup.ts" },
+  "devDependencies": { "@damienmortini/worktree-setup": "workspace:*" }
+}
+```
+
+`workspace:*` rather than a pinned version. This package is `private`, so it is never
+published; a pinned `0.0.0` would stop matching the first time `lerna version` bumps it and
+send `pnpm install` to the registry for a package that is not there. The workspace protocol
+records a `link:submodules/lib/packages/worktree-setup` entry in the lockfile and keeps
+doing so across bumps.
+
+`script/worktree-setup.ts`:
+
+```ts
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// This worktree has no node_modules yet — creating it is the point — so the setup itself is
+// resolved from the primary checkout, which does. `require.resolve` reads the package's
+// `exports`, so the entry point stays the package's business rather than a path spelled out
+// in four repositories.
+//
+// Anchored on this file rather than on the working directory, here and in the options
+// below: run from another checkout, a cwd-derived root would resolve one repository's
+// package and mirror its node_modules into another's.
+const primaryRoot = realpathSync(execFileSync('git', ['worktree', 'list', '--porcelain'], { cwd: import.meta.dirname, encoding: 'utf8' })
+  .split('\n')[0]
+  .replace(/^worktree /, '')
+  .trim());
+const resolveFromPrimary = createRequire(path.join(primaryRoot, 'package.json'));
+const { setupWorktree } = await import(pathToFileURL(resolveFromPrimary.resolve('@damienmortini/worktree-setup')).href) as typeof import('@damienmortini/worktree-setup');
+
+try {
+  await setupWorktree({
+    directory: import.meta.dirname,
+    packageDirectories: ['packages'],
+    requiredPackages: ['@damienmortini/typescript-config', '@damienmortini/eslint-config'],
+  });
+  console.log('Worktree ready.');
+}
+catch (error) {
+  // The failures here are diagnoses to read, not crashes: print the message and leave the
+  // stack out of it.
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+```
+
+A repository that already has a helper for part of that bootstrap should use it —
+`damo/script/checkout.ts` exports the same `primaryCheckoutPath` this package does, and one
+whose tree is already linked can import the pair from here instead of keeping its own.
+
+## Options
+
+Everything is off by default: each repository states what it needs, and the package assumes
+nothing about who is calling it. `WorktreeSetupOptions` in `src/index.ts` documents what
+each one is for and why.
+
+| Option | |
+| --- | --- |
+| `directory` | A directory inside the worktree to set up. Defaults to `process.cwd()`. |
+| `packageDirectories` | Where this repository's own workspace packages live, e.g. `['packages']`. |
+| `requiredPackages` | Names that must resolve once the tree is linked. |
+| `resolvedLinkDirectories` | Directories, e.g. `['submodules']`, whose committed symlinks must resolve. |
+
+## What stays on the caller's side
+
+The link tree is all this does. Anything a repository does with the tree afterwards is its
+own, because the caller is the only side that knows what its flags mean:
+
+```ts
+// damo, whose packages resolve each other through a `dist` a fresh worktree does not have.
+// `--no-build` stops after the link tree — seconds, not minutes; enough for eslint, which
+// reads source.
+const { values: { build } } = parseArgs({ allowNegative: true, options: { build: { type: 'boolean', default: true } } });
+
+await setupWorktree({ /* … */ });
+
+if (!build) {
+  console.log('Skipped the build (--no-build): eslint is ready, running the code is not. Re-run without the flag to build.');
+  process.exit(0);
+}
+console.log('Building workspace packages, this takes a couple of minutes…');
+execFileSync('pnpm', ['run', 'build'], { cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'inherit'] });
+console.log('Worktree ready.');
+```
+
+`setupWorktree` logs what it linked and throws with the whole diagnosis when the tree it
+built cannot resolve what the caller said it needs. A wrong success is worse than a clear
+failure: reporting a worktree ready when it cannot run its own gates is what sends the next
+reader looking for what their branch had broken.

--- a/packages/worktree-setup/package.json
+++ b/packages/worktree-setup/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@damienmortini/worktree-setup",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Link a fresh git worktree against the primary checkout's installed dependencies",
+  "homepage": "https://github.com/damienmortini/lib/tree/main/packages/worktree-setup",
+  "bugs": "https://github.com/damienmortini/lib/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/damienmortini/lib",
+    "directory": "packages/worktree-setup"
+  },
+  "license": "ISC",
+  "author": "Damien Mortini",
+  "type": "module",
+  "exports": "./src/index.ts",
+  "scripts": {
+    "test": "node --test src/*.test.ts"
+  }
+}

--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -148,6 +148,39 @@ test('reports committed links that dangle, which repairing node_modules does not
   );
 });
 
+test('reports a copied link it could not repair, alongside what actually failed', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // Dangles in the primary checkout as well — a stale `.bin` entry, the shape this list is
+  // made of in practice — so there is nothing to point it at.
+  await fs.mkdir(path.join(primaryRoot, 'node_modules/.bin'), { recursive: true });
+  await fs.symlink('../removed/bin/removed.js', path.join(primaryRoot, 'node_modules/.bin/removed'));
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, requiredPackages: ['@scope/absent'] }),
+    /1 copied link\(s\) could not be pointed at the primary checkout either/,
+  );
+});
+
+test('refuses a package name that would point the delete outside node_modules', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+  await fs.mkdir(path.join(primaryRoot, 'node_modules'), { recursive: true });
+
+  const escapee = path.join(path.dirname(primaryRoot), 'do-not-delete-me');
+  await write(path.join(escapee, 'kept.txt'), 'still here');
+  await write(
+    path.join(worktreeRoot, 'packages/malicious/package.json'),
+    JSON.stringify({ name: `../../${path.basename(escapee)}` }),
+  );
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] }),
+    /declares an unusable name/,
+  );
+  // The point of the guard: `fs.rm` never ran against it.
+  assert.equal(existsSync(path.join(escapee, 'kept.txt')), true);
+});
+
 test('refuses to run in the primary checkout, whose node_modules it would delete', async () => {
   const { primaryRoot } = await checkouts();
   await fs.mkdir(path.join(primaryRoot, 'node_modules'), { recursive: true });

--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -1,0 +1,157 @@
+// Exercised against real git worktrees and real symlinks, because that is what the subject
+// is: every interesting case here — a relative link that dangles once it is copied, a
+// package only the branch has — is a fact about the filesystem, and a stubbed one would
+// prove nothing about the tree these repositories actually get.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+
+import { setupWorktree } from './index.ts';
+
+const temporaryRoots: string[] = [];
+
+after(async () => {
+  for (const root of temporaryRoots) await fs.rm(root, { recursive: true, force: true });
+});
+
+function git(gitArguments: string[], directory: string): void {
+  execFileSync('git', gitArguments, { cwd: directory, stdio: 'ignore' });
+}
+
+async function write(filePath: string, contents: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, contents);
+}
+
+/**
+ * A primary checkout with one commit and a linked worktree beside it, both under a
+ * directory that is removed afterwards. Resolved, so the paths match what the setup reads
+ * back from git on a platform where the temporary directory is itself a symlink.
+ */
+async function checkouts(): Promise<{ primaryRoot: string; worktreeRoot: string }> {
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-setup-')));
+  temporaryRoots.push(root);
+
+  const primaryRoot = path.join(root, 'repository');
+  await write(path.join(primaryRoot, 'package.json'), '{"name":"repository"}');
+  git(['init', '--initial-branch=main'], primaryRoot);
+  git(['add', '.'], primaryRoot);
+  git(['-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-m', 'initial'], primaryRoot);
+
+  const worktreeRoot = path.join(root, 'repository-worktree');
+  git(['worktree', 'add', '-b', 'branch', worktreeRoot], primaryRoot);
+
+  return { primaryRoot, worktreeRoot };
+}
+
+test('mirrors the primary checkout, copying relative links and skipping pnpm bookkeeping', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+  const modules = path.join(primaryRoot, 'node_modules');
+
+  await write(path.join(modules, 'installed/index.js'), '');
+  await write(path.join(modules, '.modules.yaml'), 'hoistPattern: []');
+  await write(path.join(modules, '.pnpm/registry/index.js'), '');
+  await write(path.join(primaryRoot, 'packages/local/index.js'), '');
+  await fs.mkdir(path.join(modules, '@scope'), { recursive: true });
+  await fs.symlink('../../packages/local', path.join(modules, '@scope/local'));
+  await fs.mkdir(path.join(modules, '.bin'), { recursive: true });
+  await fs.symlink('../@scope/local/index.js', path.join(modules, '.bin/local'));
+  // The worktree has the branch's own copy of the package the relative links point at.
+  await write(path.join(worktreeRoot, 'packages/local/index.js'), '');
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  const worktreeModules = path.join(worktreeRoot, 'node_modules');
+  assert.equal(await fs.readlink(path.join(worktreeModules, 'installed')), path.join(modules, 'installed'));
+  // Copied verbatim, so it resolves to the worktree's own package rather than the primary's.
+  assert.equal(await fs.readlink(path.join(worktreeModules, '@scope/local')), '../../packages/local');
+  assert.equal(await fs.realpath(path.join(worktreeModules, '@scope/local')), path.join(worktreeRoot, 'packages/local'));
+  assert.equal(await fs.readlink(path.join(worktreeModules, '.bin/local')), '../@scope/local/index.js');
+  // Leaving these out is what keeps an install run here from writing back into the primary.
+  assert.equal(existsSync(path.join(worktreeModules, '.modules.yaml')), false);
+  assert.equal(existsSync(path.join(worktreeModules, '.pnpm')), false);
+});
+
+test('links a package the branch adds, which the primary checkout knows nothing about', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  await fs.mkdir(path.join(primaryRoot, 'node_modules'), { recursive: true });
+  await write(path.join(worktreeRoot, 'packages/added/package.json'), '{"name":"@scope/added"}');
+  // Nested where pnpm nests what it cannot hoist, and only in the primary.
+  await write(path.join(primaryRoot, 'packages/added/node_modules/dependency/index.js'), '');
+
+  await setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] });
+
+  assert.equal(
+    await fs.realpath(path.join(worktreeRoot, 'node_modules/@scope/added')),
+    path.join(worktreeRoot, 'packages/added'),
+  );
+  assert.equal(existsSync(path.join(worktreeRoot, 'packages/added/node_modules/dependency')), true);
+});
+
+test('points a copied link that dangles here at the primary checkout', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // What `submodules/<name>` does in these repositories: a relative link out of the
+  // checkout, resolving only for one sitting directly beside its target.
+  await write(path.join(path.dirname(primaryRoot), 'sibling/packages/config/index.js'), '');
+  await fs.mkdir(path.join(primaryRoot, 'submodules'), { recursive: true });
+  await fs.symlink('../../sibling', path.join(primaryRoot, 'submodules/sibling'));
+  await fs.mkdir(path.join(primaryRoot, 'node_modules/@scope'), { recursive: true });
+  await fs.symlink('../../submodules/sibling/packages/config', path.join(primaryRoot, 'node_modules/@scope/config'));
+
+  await setupWorktree({ directory: worktreeRoot, requiredPackages: ['@scope/config'] });
+
+  // The worktree has no `submodules`, so the copied link dangled and was repaired.
+  assert.equal(
+    await fs.realpath(path.join(worktreeRoot, 'node_modules/@scope/config')),
+    path.join(path.dirname(primaryRoot), 'sibling/packages/config'),
+  );
+});
+
+test('reports a required package it cannot resolve, without blaming a link that did resolve', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+  await fs.mkdir(path.join(primaryRoot, 'node_modules'), { recursive: true });
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, requiredPackages: ['@scope/absent'] }),
+    (error: Error) => {
+      assert.match(error.message, /Cannot resolve @scope\/absent/);
+      // Nothing dangled, so where the worktree lives is not the answer: a package that is
+      // simply not installed must not send a reader off to move a worktree.
+      assert.doesNotMatch(error.message, /git worktree add/);
+      assert.doesNotMatch(error.message, /could not be pointed at the primary checkout/);
+      return true;
+    },
+  );
+});
+
+test('reports committed links that dangle, which repairing node_modules does not fix', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+  await fs.mkdir(path.join(primaryRoot, 'node_modules'), { recursive: true });
+  await fs.mkdir(path.join(worktreeRoot, 'submodules'), { recursive: true });
+  await fs.symlink('../../sibling', path.join(worktreeRoot, 'submodules/sibling'));
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, resolvedLinkDirectories: ['submodules'] }),
+    (error: Error) => {
+      assert.match(error.message, /submodules\/sibling dangle from here/);
+      // Here the location is the answer, so it is said — and says where.
+      assert.match(error.message, new RegExp(`git worktree add ${path.join(path.dirname(primaryRoot), '<name>')}`));
+      return true;
+    },
+  );
+});
+
+test('refuses to run in the primary checkout, whose node_modules it would delete', async () => {
+  const { primaryRoot } = await checkouts();
+  await fs.mkdir(path.join(primaryRoot, 'node_modules'), { recursive: true });
+
+  await assert.rejects(setupWorktree({ directory: primaryRoot }), /is the primary checkout/);
+  assert.equal(existsSync(path.join(primaryRoot, 'node_modules')), true);
+});

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -1,0 +1,245 @@
+// A fresh git worktree has no node_modules at all, so nothing resolves in it — not a
+// workspace package, not a third-party dependency, not a local binary. Installing into the
+// worktree is not an option either: these repositories reach their siblings through
+// `submodules/*` symlinks, so an install there writes outside the worktree and into the
+// checkouts other agents are working in. This mirrors the primary checkout's node_modules
+// instead: every installed package is symlinked across, while scope directories (`@scope`,
+// `@types`, …) and `.bin` are recreated with their original relative links, so workspace
+// specifiers resolve to the worktree's own packages rather than the primary checkout's —
+// including packages the branch adds, which the primary checkout knows nothing about.
+//
+// One copy, four repositories. Everything below is the same everywhere; what differs
+// between them is passed in as options, so a fix lands once rather than being re-derived
+// per repository — which is how the copies drifted apart in the first place.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, realpathSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface WorktreeSetupOptions {
+  /** A directory inside the worktree to set up. Defaults to the current working directory. */
+  directory?: string;
+  /**
+   * Directories holding workspace packages, relative to the worktree root — `packages` for
+   * a repository that has its own, nothing for one whose packages all come from submodules.
+   * Missing directories are skipped, so a branch may add or drop one.
+   */
+  packageDirectories?: string[];
+  /**
+   * Package names that must resolve from the worktree once the tree is linked. Name the
+   * ones whose absence a repository's gates report as something else entirely: tsc reports
+   * a config it cannot find and a cascade of missing globals, eslint dies in module
+   * resolution with no message at all.
+   */
+  requiredPackages?: string[];
+  /**
+   * Directories whose committed symlinks must resolve from the worktree — `submodules` for
+   * a repository whose sources name `submodules/…` paths directly, since repairing
+   * node_modules does not repair the tracked links themselves.
+   */
+  resolvedLinkDirectories?: string[];
+}
+
+function git(gitArguments: string[], directory: string): string {
+  return execFileSync('git', gitArguments, { cwd: directory, encoding: 'utf8' }).trim();
+}
+
+// Both answers come back resolved, because they are compared to each other: git resolves
+// `--show-toplevel` itself while `git worktree list` reports the path recorded when the
+// worktree was registered — equal here, but not something the comparison should rest on
+// across git versions and platforms (`/tmp` → `/private/tmp`, symlinked CI checkouts). One
+// directory spelled two ways would clear the guard below as "this is a linked worktree",
+// pointing the mirroring at the primary's own node_modules, which `materialize` deletes
+// before it reads. That directory is shared with every other worktree and costs a full
+// install.
+
+/** The root of the checkout `directory` is in, primary or linked worktree. */
+export function currentCheckoutPath(directory: string): string {
+  return realpathSync(git(['rev-parse', '--show-toplevel'], directory));
+}
+
+/** The root of the primary checkout — the one worktree that is not throwaway. */
+export function primaryCheckoutPath(directory: string): string {
+  // git lists the main worktree — the one holding the installed node_modules — first.
+  return realpathSync(git(['worktree', 'list', '--porcelain'], directory).split('\n')[0].replace(/^worktree /, ''));
+}
+
+/**
+ * Recreate `source` at `target` as a tree of symlinks: relative links are copied verbatim
+ * so they resolve inside the worktree, everything else points at the primary. Removing
+ * `target` first keeps re-runs idempotent. Every copied link is recorded in `copiedLinks`
+ * for `repairDanglingLinks` to look at afterwards.
+ */
+async function materialize(source: string, target: string, copiedLinks: string[]): Promise<void> {
+  await fs.rm(target, { recursive: true, force: true });
+  await fs.mkdir(target, { recursive: true });
+
+  for (const entry of await fs.readdir(source, { withFileTypes: true })) {
+    // pnpm's own bookkeeping (`.modules.yaml`, `.pnpm`, …) describes the primary checkout.
+    // Linking it would let an install run here write back into the shared checkout, so
+    // leave it out and let pnpm treat this worktree as the uninstalled tree it is.
+    if (entry.name.startsWith('.') && entry.name !== '.bin') continue;
+
+    const sourcePath = path.join(source, entry.name);
+    const targetPath = path.join(target, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      await fs.symlink(await fs.readlink(sourcePath), targetPath);
+      copiedLinks.push(targetPath);
+    }
+    else if (entry.isDirectory() && (entry.name.startsWith('@') || entry.name === '.bin')) {
+      await materialize(sourcePath, targetPath, copiedLinks);
+    }
+    else {
+      await fs.symlink(sourcePath, targetPath);
+    }
+  }
+}
+
+/**
+ * Point the copied links that do not resolve here at the primary checkout instead, and
+ * return the ones that could not be repaired.
+ *
+ * `submodules/<name>` is a committed relative symlink (`../../<name>`), so it resolves only
+ * for a checkout sitting directly beside the repositories it names — which a worktree
+ * created anywhere else is not. Every `node_modules` entry that points through one dangles
+ * in such a worktree, taking whole scopes with it.
+ *
+ * The primary resolves them, so its own path is what these are pointed at — the same real
+ * directory it reads. Repointing rather than rewriting `submodules/*`: those are tracked
+ * files, and editing them would leave every worktree permanently dirty with a modification
+ * an agent could commit.
+ *
+ * Run once the whole tree is built rather than as each link is made: a `.bin` entry points
+ * at a sibling package that may not have been linked yet, so a check made on the way past
+ * would read it as dangling and repoint it at the primary — undoing exactly what copying
+ * relative links verbatim is for.
+ */
+async function repairDanglingLinks(copiedLinks: string[], worktreeRoot: string, primaryRoot: string): Promise<string[]> {
+  const unrepaired: string[] = [];
+
+  for (const link of copiedLinks) {
+    // Follows the link, so this is false for one that dangles.
+    if (existsSync(link)) continue;
+    const primaryPath = path.join(primaryRoot, path.relative(worktreeRoot, link));
+    if (!existsSync(primaryPath)) {
+      unrepaired.push(link);
+      continue;
+    }
+    await fs.rm(link, { force: true });
+    await fs.symlink(realpathSync(primaryPath), link);
+  }
+
+  return unrepaired;
+}
+
+/** Directories holding a package.json under `directory`, relative to the worktree root. */
+async function findPackageDirectories(worktreeRoot: string, directory: string): Promise<string[]> {
+  const directories: string[] = [];
+
+  for (const entry of await fs.readdir(path.join(worktreeRoot, directory), { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const child = path.join(directory, entry.name);
+    if (existsSync(path.join(worktreeRoot, child, 'package.json'))) directories.push(child);
+    directories.push(...await findPackageDirectories(worktreeRoot, child));
+  }
+
+  return directories;
+}
+
+/** The symlinks directly inside `directory` that do not resolve, relative to the worktree root. */
+async function danglingLinksIn(worktreeRoot: string, directory: string): Promise<string[]> {
+  if (!existsSync(path.join(worktreeRoot, directory))) return [];
+
+  return (await fs.readdir(path.join(worktreeRoot, directory), { withFileTypes: true }))
+    .filter(entry => entry.isSymbolicLink() && !existsSync(path.join(worktreeRoot, directory, entry.name)))
+    .map(entry => path.join(directory, entry.name));
+}
+
+/**
+ * Link a fresh worktree against the primary checkout's installed dependencies. Logs what it
+ * linked; throws with the whole diagnosis when the tree it built cannot resolve what the
+ * caller said it needs — a wrong success is worse than a clear failure, and reporting a
+ * worktree ready when it cannot run its own gates is what sends the next reader looking for
+ * what their branch had broken.
+ *
+ * The link tree is all of it. Whatever a repository does with the tree afterwards — build
+ * its packages, announce itself done — is the caller's, which is also the only side that
+ * knows whether a flag asked it to be skipped.
+ */
+export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise<void> {
+  const {
+    directory = process.cwd(),
+    packageDirectories = [],
+    requiredPackages = [],
+    resolvedLinkDirectories = [],
+  } = options;
+
+  const worktreeRoot = currentCheckoutPath(directory);
+  const primaryRoot = primaryCheckoutPath(directory);
+
+  if (worktreeRoot === primaryRoot) {
+    throw new Error(`${worktreeRoot} is the primary checkout — run this from inside a linked worktree (its node_modules comes from \`pnpm install\`).`);
+  }
+
+  const copiedLinks: string[] = [];
+  await materialize(path.join(primaryRoot, 'node_modules'), path.join(worktreeRoot, 'node_modules'), copiedLinks);
+  let linked = 1;
+
+  // The worktree's own packages drive this, not the primary checkout's: a package added on
+  // the branch exists in neither the primary's tree nor its hoisted scope, and used to be
+  // the one thing agents still had to link by hand. Resolving to the primary instead is
+  // also what silently breaks a dev server that serves the worktree — a package reached
+  // through a path outside that root renders as a blank element.
+  for (const packageRoot of packageDirectories) {
+    if (!existsSync(path.join(worktreeRoot, packageRoot))) continue;
+
+    for (const packageDirectory of await findPackageDirectories(worktreeRoot, packageRoot)) {
+      const nestedModules = path.join(primaryRoot, packageDirectory, 'node_modules');
+      if (existsSync(nestedModules)) {
+        // pnpm nests what it cannot hoist — a version conflict, and the workspace links
+        // between sibling packages, which are relative and so follow the worktree's own
+        // sources across.
+        await materialize(nestedModules, path.join(worktreeRoot, packageDirectory, 'node_modules'), copiedLinks);
+        linked++;
+      }
+
+      const { name } = JSON.parse(await fs.readFile(path.join(worktreeRoot, packageDirectory, 'package.json'), 'utf8'));
+      const scopedLink = path.join(worktreeRoot, 'node_modules', name);
+      await fs.mkdir(path.dirname(scopedLink), { recursive: true });
+      await fs.rm(scopedLink, { recursive: true, force: true });
+      await fs.symlink(path.relative(path.dirname(scopedLink), path.join(worktreeRoot, packageDirectory)), scopedLink);
+    }
+  }
+
+  const unrepaired = await repairDanglingLinks(copiedLinks, worktreeRoot, primaryRoot);
+
+  console.log(`Linked ${linked} node_modules ${linked === 1 ? 'directory' : 'directories'} from ${primaryRoot}.`);
+
+  const missingPackages = requiredPackages.filter(name => !existsSync(path.join(worktreeRoot, 'node_modules', name)));
+  const danglingLinks = (await Promise.all(resolvedLinkDirectories.map(directory => danglingLinksIn(worktreeRoot, directory)))).flat();
+
+  // Reported together when they happen together: they share a cause, and fixing where the
+  // worktree lives fixes both at once.
+  if (missingPackages.length > 0 || danglingLinks.length > 0) {
+    const reasons: string[] = [];
+    if (missingPackages.length > 0) {
+      reasons.push(`Cannot resolve ${missingPackages.join(' or ')} from ${worktreeRoot}.`);
+    }
+    if (unrepaired.length > 0) {
+      reasons.push(`${unrepaired.length} copied link(s) could not be pointed at the primary checkout either.`);
+    }
+    if (danglingLinks.length > 0) {
+      reasons.push(`${danglingLinks.join(' and ')} dangle from here, and repairing node_modules does not repair the tracked links themselves.`);
+    }
+    // Where the worktree lives is the answer to a link that dangles, and only to that. Said
+    // unconditionally it would send a reader whose package is merely not installed off to
+    // move a worktree that was never in the wrong place — a confident wrong diagnosis, which
+    // is worse than none at all and is exactly what this package exists to stop repeating.
+    if (unrepaired.length > 0 || danglingLinks.length > 0) {
+      reasons.push(`Links committed as \`../../<name>\` resolve only for a checkout sitting directly under ${path.dirname(primaryRoot)} — and this worktree is at ${worktreeRoot}. Create it there instead: \`git worktree add ${path.join(path.dirname(primaryRoot), '<name>')}\`.`);
+    }
+    throw new Error(reasons.join('\n'));
+  }
+}

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -213,7 +213,17 @@ export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise
       }
 
       const { name } = JSON.parse(await fs.readFile(path.join(worktreeRoot, packageDirectory, 'package.json'), 'utf8'));
-      const scopedLink = path.join(worktreeRoot, 'node_modules', name);
+      const modulesRoot = path.join(worktreeRoot, 'node_modules');
+      const scopedLink = typeof name === 'string' ? path.join(modulesRoot, name) : '';
+      // `name` is whatever the branch being set up wrote in a package.json, and two lines
+      // below it drives a recursive forced delete. `path.join` collapses `..`, so a name
+      // spelled to climb out of the tree would aim that delete anywhere the user can write —
+      // and a worktree is often somebody else's branch, checked out to review it. Contained
+      // here rather than trusted, and the same check catches a package.json with no name at
+      // all, which a stray fixture under `packageDirectories` can perfectly well be.
+      if (!scopedLink.startsWith(modulesRoot + path.sep)) {
+        throw new Error(`${packageDirectory}/package.json declares an unusable name (${JSON.stringify(name)}): the workspace link it asks for would land outside ${modulesRoot}.`);
+      }
       await fs.mkdir(path.dirname(scopedLink), { recursive: true });
       await fs.rm(scopedLink, { recursive: true, force: true });
       await fs.symlink(path.relative(path.dirname(scopedLink), path.join(worktreeRoot, packageDirectory)), scopedLink);
@@ -223,6 +233,16 @@ export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise
   const unrepaired = await repairDanglingLinks(copiedLinks, worktreeRoot, primaryRoot);
 
   console.log(`Linked ${linked} node_modules ${linked === 1 ? 'directory' : 'directories'} from ${primaryRoot}.`);
+
+  // Said out loud rather than left to the failure below, which only mentions these when
+  // something else went wrong at the same time. Not a failure on its own: a link reaches
+  // this list by dangling in the primary checkout too — a stale `.bin` entry pnpm left
+  // behind, most of the time — so the worktree is no worse off than the tree it mirrors,
+  // and failing over it would blame the branch for the state of the checkout beside it.
+  // Worth a line all the same, because it is the answer when something later will not run.
+  if (unrepaired.length > 0) {
+    console.log(`${unrepaired.length} copied link(s) dangle here and in ${primaryRoot} too, so they were left alone.`);
+  }
 
   const missingPackages = requiredPackages.filter(name => !existsSync(path.join(worktreeRoot, 'node_modules', name)));
   const danglingLinks = (await Promise.all(resolvedLinkDirectories.map(directory => danglingLinksIn(worktreeRoot, directory)))).flat();

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -134,7 +134,14 @@ async function repairDanglingLinks(copiedLinks: string[], worktreeRoot: string, 
   return unrepaired;
 }
 
-/** Directories holding a package.json under `directory`, relative to the worktree root. */
+/**
+ * Directories holding a package.json under `directory`, relative to the worktree root.
+ *
+ * The walk carries on past a package it finds rather than stopping there, because pnpm's
+ * `packages/**` glob matches a package nested inside another one. None of the repositories
+ * using this has such a package today, which is exactly why a shallow scan would look
+ * correct here — and would then quietly stop linking the first nested package somebody adds.
+ */
 async function findPackageDirectories(worktreeRoot: string, directory: string): Promise<string[]> {
   const directories: string[] = [];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@damienmortini/typescript-config':
         specifier: workspace:^
         version: link:packages/typescript-config
+      '@damienmortini/worktree-setup':
+        specifier: workspace:*
+        version: link:packages/worktree-setup
       eslint:
         specifier: 10.5.0
         version: 10.5.0(supports-color@7.2.0)
@@ -468,6 +471,8 @@ importers:
       '@damienmortini/math':
         specifier: 0.0.28
         version: link:../math
+
+  packages/worktree-setup: {}
 
 packages:
 

--- a/script/worktree-setup.ts
+++ b/script/worktree-setup.ts
@@ -1,98 +1,32 @@
-// A fresh git worktree has no node_modules at all, so nothing resolves in it — not a
-// workspace package, not a third-party dependency, not a local binary. `pnpm install`
-// would fix that, but it re-runs every postinstall build and rewrites the lockfile for a
-// checkout that is usually thrown away within the hour; this mirrors the primary
-// checkout's node_modules in about a second instead. Every installed package is symlinked
-// across, while scope directories (`@damienmortini`, `@types`, …) and `.bin` are recreated
-// with their original relative links, so workspace specifiers resolve to the worktree's
-// own packages rather than the primary checkout's.
+// Link this worktree against the primary checkout's installed dependencies. The work lives
+// in `@damienmortini/worktree-setup`, shared with the repositories that used to carry their
+// own copy of it; this states what lib needs and nothing else.
 //
-// The link tree covers everything that reads source directly: eslint across the repo, and
-// a package's own tests and typecheck — `packages/server` runs both off `src`. A sibling
-// imported by name resolves to its `dist`, which a fresh worktree has not built, so
-// typechecking or running code that crosses package boundaries needs `pnpm run build`
-// first. Run this from inside the worktree.
+// Imported by path rather than by name, unlike the consumer repositories: the package is in
+// this repository, so a worktree runs the copy on its own branch — which is what makes a
+// change to it testable from a worktree at all. Resolving through node_modules here would
+// run the primary checkout's copy instead.
 
-import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import fs from 'node:fs/promises';
-import path from 'node:path';
+import { setupWorktree } from '../packages/worktree-setup/src/index.ts';
 
-// Both roots are resolved before anything compares them: `git rev-parse` resolves symlinks
-// while `git worktree list` echoes each path as it was registered, and one directory
-// spelled two ways would clear the guard below as "this is a linked worktree" — pointing
-// the mirroring at the primary's own node_modules, which materialize deletes before it
-// reads. That directory is shared with every other worktree and costs a full install.
-const worktreeRoot = await fs.realpath(execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim());
-// git lists the main worktree — the one holding the installed node_modules — first.
-const primaryRoot = await fs.realpath(execFileSync('git', ['worktree', 'list', '--porcelain'], { encoding: 'utf8' })
-  .split('\n')[0]
-  .replace(/^worktree /, '')
-  .trim());
-
-if (worktreeRoot === primaryRoot) {
-  console.error(`${worktreeRoot} is the primary checkout — run this from inside a linked worktree (its node_modules comes from \`pnpm install\`).`);
+try {
+  await setupWorktree({
+    // The worktree this file is in, not whichever checkout the shell happens to sit in: run
+    // from elsewhere, a cwd-derived root would mirror one repository's node_modules into
+    // another's.
+    directory: import.meta.dirname,
+    packageDirectories: ['packages'],
+    // Both gates resolve through these: `eslint .` extends the config package, and every
+    // package's `tsc` build extends the TypeScript one. Neither says so when it is missing.
+    requiredPackages: ['@damienmortini/eslint-config', '@damienmortini/typescript-config'],
+  });
+  // lib's packages are read from source by everything that runs here, so the link tree is
+  // the whole of "ready" — the repositories that need `pnpm run build` first run it here.
+  console.log('Worktree ready.');
+}
+catch (error) {
+  // The failures here are diagnoses to read, not crashes: print the message and leave the
+  // stack out of it.
+  console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }
-
-/**
- * Recreate `source` at `target` as a tree of symlinks: relative links are copied
- * verbatim so they resolve inside the worktree, everything else points at the primary.
- * Removing `target` first keeps re-runs idempotent.
- */
-async function materialize(source: string, target: string): Promise<void> {
-  await fs.rm(target, { recursive: true, force: true });
-  await fs.mkdir(target, { recursive: true });
-
-  for (const entry of await fs.readdir(source, { withFileTypes: true })) {
-    // pnpm's own bookkeeping (`.modules.yaml`, `.pnpm`, …) describes the primary checkout.
-    // Linking it would let an install run here write back into the shared checkout, so
-    // leave it out and let pnpm treat this worktree as the uninstalled tree it is.
-    if (entry.name.startsWith('.') && entry.name !== '.bin') continue;
-
-    const sourcePath = path.join(source, entry.name);
-    const targetPath = path.join(target, entry.name);
-
-    if (entry.isSymbolicLink()) {
-      await fs.symlink(await fs.readlink(sourcePath), targetPath);
-    }
-    else if (entry.isDirectory() && (entry.name.startsWith('@') || entry.name === '.bin')) {
-      await materialize(sourcePath, targetPath);
-    }
-    else {
-      await fs.symlink(sourcePath, targetPath);
-    }
-  }
-}
-
-/**
- * node_modules directories nested under `directory`, relative to the primary checkout.
- * Never descends into one: a match found deeper inside would be materialized through a
- * symlink and write into the primary checkout.
- */
-async function nestedModulesDirectories(directory: string): Promise<string[]> {
-  const directories: string[] = [];
-
-  for (const entry of await fs.readdir(path.join(primaryRoot, directory), { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const child = path.join(directory, entry.name);
-    if (entry.name === 'node_modules') directories.push(child);
-    else directories.push(...await nestedModulesDirectories(child));
-  }
-
-  return directories;
-}
-
-await materialize(path.join(primaryRoot, 'node_modules'), path.join(worktreeRoot, 'node_modules'));
-
-// pnpm nests what it cannot hoist — a version conflict, and the workspace links between
-// sibling packages, which are relative and so follow the worktree's own sources across.
-const nestedModules = (await nestedModulesDirectories('packages'))
-  // A branch that deletes a package must not get its node_modules recreated underneath.
-  .filter(directory => existsSync(path.join(worktreeRoot, path.dirname(directory))));
-
-for (const directory of nestedModules) {
-  await materialize(path.join(primaryRoot, directory), path.join(worktreeRoot, directory));
-}
-
-console.log(`Linked ${nestedModules.length + 1} node_modules directories from ${primaryRoot}. Worktree ready.`);


### PR DESCRIPTION
Todo #162, split into one todo per repository: this is the `~/lib` part, which publishes the package. #182 (damo), #183 (playground) and #184 (graph) adopt it and depend on this merging first.

## What was wrong

The four repositories were each running their own `script/worktree-setup.ts`, and the copies had drifted apart:

| | lib | damo | playground | graph |
| --- | --- | --- | --- | --- |
| `copiedLinks` / `repairDanglingLinks` | – | yes | yes | – |
| workspace scope links for branch-added packages | – | yes | – | yes |
| required-package gate | – | yes | yes | – |
| dangling `submodules/*` check | – | – | yes | – |
| `pnpm run build` | – | yes | – | – |
| both checkout roots realpath'd | yes | yes | – | – |

So a fix could not be copied, only re-derived — which is how todo #107 turned into #128, #145 and #146 for one one-line guard.

## What this does

`packages/worktree-setup` is the single copy, and it is the **union** of the four, not the intersection: every behaviour any one of them had is now available to all four. The per-repository differences are options — `packageDirectories`, `requiredPackages`, `resolvedLinkDirectories` — so the package stays dumb about who is calling it.

`~/lib`'s own script becomes the caller. It imports the package by relative path rather than by name, unlike the three consumers, so a lib worktree runs the copy on its own branch; resolving through `node_modules` there would run the primary checkout's copy and make a change to this package untestable from a worktree.

## Two things to know when reading it

**lib gains semantics it did not have.** The walk reads the *worktree's* package directories rather than the primary's nested `node_modules`, so lib worktrees now get `node_modules/<name>` links for all 26 workspace packages. That is what makes a package added on a branch resolve at all (damo and graph already worked this way), but it does mean a lib worktree resolves workspace packages its primary checkout does not — an undeclared cross-package import would pass in a worktree and fail on main.

**There is no `bin`.** A fresh worktree has no `node_modules/.bin`, and that tree is precisely what this creates, so while the command runs from inside the worktree a bin cannot be the entry point. Each repository keeps a ~15-line `script/worktree-setup.ts` that finds the primary checkout with git and imports the package from *its* `node_modules`. The README documents that bootstrap verbatim for the three adoptions.

The build step stayed on the caller's side rather than becoming a `build` option, which is a deliberate departure from the todo's sketch: damo needs `parseArgs` for `--no-build` regardless, so the option shrank nothing and would have put pnpm-invocation knowledge inside a package whose job is the link tree.

## Verification

- 6 tests against **real** git worktrees and real symlinks — mirroring, verbatim relative links, `.pnpm`/`.modules.yaml` exclusion, branch-added packages, dangling-link repair, both failure diagnoses, and the primary-checkout refusal.
- `npx eslint` clean; typechecks under lib's shared TypeScript config.
- Ran in this worktree from scratch (`Linked 30 node_modules directories`), and from a foreign working directory to confirm it anchors on its own file rather than `process.cwd()`.
- `pnpm install --frozen-lockfile --lockfile-only` green.

The lib devDependency is declared as `workspace:*`, which records `link:packages/worktree-setup` in the lockfile. That is deliberate and the README explains it: this package is `private`, so a pinned `0.0.0` would stop matching the first time `lerna version` bumps it and send `pnpm install` to the registry for a package that is never published — a 404 in all three consumers at once, triggered by an unrelated lib release. Declaring it here means lib's own frozen-install CI proves the mechanism before three repositories copy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4Bb7VjQk3ThE7FsRzPNZt