### PR TITLE
Keep branch-deleted package links dangling

### DIFF
--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -137,6 +137,22 @@ test('leaves a link dangling when the branch is what deleted the package it name
   assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/.bin/gone')), false);
 });
 
+test('repairs a link into the primary store, which is nothing a branch adds or deletes', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // What a non-hoisted `nodeLinker` writes: every dependency is a link into `.pnpm`, which
+  // `materialize` leaves out on purpose, so the copied link dangles here like any other.
+  const store = 'node_modules/.pnpm/dependency@1.0.0/node_modules/dependency';
+  await write(path.join(primaryRoot, store, 'index.js'), '');
+  await fs.symlink(path.join('.pnpm/dependency@1.0.0/node_modules/dependency'), path.join(primaryRoot, 'node_modules/dependency'));
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  // Inside the primary checkout, but the installed tree rather than the branch's own, so the
+  // worktree has nothing of its own to prefer and the primary answers for it.
+  assert.equal(await fs.realpath(path.join(worktreeRoot, 'node_modules/dependency')), path.join(primaryRoot, store));
+});
+
 test('reports a required package it cannot resolve, without blaming a link that did resolve', async () => {
   const { primaryRoot, worktreeRoot } = await checkouts();
   await fs.mkdir(path.join(primaryRoot, 'node_modules'), { recursive: true });

--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -107,11 +107,34 @@ test('points a copied link that dangles here at the primary checkout', async () 
 
   await setupWorktree({ directory: worktreeRoot, requiredPackages: ['@scope/config'] });
 
-  // The worktree has no `submodules`, so the copied link dangled and was repaired.
+  // The worktree has no `submodules`, so the copied link dangled — and it names a directory
+  // outside the checkout, which is the same real one either checkout reaches, so it was
+  // repaired.
   assert.equal(
     await fs.realpath(path.join(worktreeRoot, 'node_modules/@scope/config')),
     path.join(path.dirname(primaryRoot), 'sibling/packages/config'),
   );
+});
+
+test('leaves a link dangling when the branch is what deleted the package it names', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // Hoisted in the primary, which still has the package; the branch deleted `packages/gone`,
+  // so its copy of the link dangles for a reason the primary checkout is not the answer to.
+  await write(path.join(primaryRoot, 'packages/gone/index.js'), '');
+  await fs.mkdir(path.join(primaryRoot, 'node_modules/@scope'), { recursive: true });
+  await fs.symlink('../../packages/gone', path.join(primaryRoot, 'node_modules/@scope/gone'));
+  // pnpm gives a workspace package a `.bin` entry through its hoisted link, so repointing
+  // that one at the primary would resolve the deleted package's code just as well.
+  await fs.mkdir(path.join(primaryRoot, 'node_modules/.bin'), { recursive: true });
+  await fs.symlink('../@scope/gone/index.js', path.join(primaryRoot, 'node_modules/.bin/gone'));
+  await fs.mkdir(path.join(worktreeRoot, 'packages'), { recursive: true });
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  // Left exactly as it was copied, so it resolves to nothing rather than to the primary's.
+  assert.equal(await fs.readlink(path.join(worktreeRoot, 'node_modules/@scope/gone')), '../../packages/gone');
+  assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/.bin/gone')), false);
 });
 
 test('reports a required package it cannot resolve, without blaming a link that did resolve', async () => {

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -115,6 +115,17 @@ async function materialize(source: string, target: string, copiedLinks: string[]
  * at a sibling package that may not have been linked yet, so a check made on the way past
  * would read it as dangling and repoint it at the primary — undoing exactly what copying
  * relative links verbatim is for.
+ *
+ * A branch that deletes a workspace package dangles its hoisted link exactly the same way,
+ * and must not be repaired: the primary still has the package, so pointing there would
+ * resolve an import the branch removed against code the branch does not have — the mirror
+ * image of a package the branch adds, and wrong for the same reason. The link cannot say
+ * which happened, since `submodules/lib/packages/x` and `packages/x` alike sit under the
+ * worktree root; where the primary resolves it can. Content the checkout itself holds is the
+ * branch's to delete, so the worktree's own copy is the only answer; content outside it is
+ * the same real directory either checkout would reach, which is what makes the primary a
+ * stand-in at all. Its node_modules is neither — that is the installed store, which no branch
+ * adds to or deletes from.
  */
 async function repairDanglingLinks(copiedLinks: string[], worktreeRoot: string, primaryRoot: string): Promise<string[]> {
   const unrepaired: string[] = [];
@@ -127,8 +138,13 @@ async function repairDanglingLinks(copiedLinks: string[], worktreeRoot: string, 
       unrepaired.push(link);
       continue;
     }
+    const primaryTarget = realpathSync(primaryPath);
+    const fromPrimaryRoot = path.relative(primaryRoot, primaryTarget).split(path.sep);
+    // Inside the checkout and outside any node_modules: content of the branch's own, which
+    // only the worktree's copy can answer for.
+    if (fromPrimaryRoot[0] !== '..' && !fromPrimaryRoot.includes('node_modules')) continue;
     await fs.rm(link, { force: true });
-    await fs.symlink(realpathSync(primaryPath), link);
+    await fs.symlink(primaryTarget, link);
   }
 
   return unrepaired;

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -124,8 +124,10 @@ async function materialize(source: string, target: string, copiedLinks: string[]
  * worktree root; where the primary resolves it can. Content the checkout itself holds is the
  * branch's to delete, so the worktree's own copy is the only answer; content outside it is
  * the same real directory either checkout would reach, which is what makes the primary a
- * stand-in at all. Its node_modules is neither — that is the installed store, which no branch
- * adds to or deletes from.
+ * stand-in at all. A node_modules on the way is neither — installed contents, which no branch
+ * adds to or deletes from. Any of them, not just the checkout's own: `materialize` mirrors
+ * the nested trees pnpm writes under `packages/<name>/node_modules` too, and a non-hoisted
+ * layout puts a store in each one.
  */
 async function repairDanglingLinks(copiedLinks: string[], worktreeRoot: string, primaryRoot: string): Promise<string[]> {
   const unrepaired: string[] = [];


### PR DESCRIPTION
Closes todo #188. Found reviewing #58, which consolidated the four copies of the worktree setup into `@damienmortini/worktree-setup`; the behaviour is pre-existing in damo and playground and is now shared by all four repositories.

## The bug

`repairDanglingLinks` repoints every copied `node_modules` link that does not resolve in the worktree at the primary checkout. That is right for what it was written for: a worktree created away from its siblings dangles the committed `submodules/<name>` links, taking the whole `@damienmortini` scope with it.

It fires just as readily when a branch **deletes** a workspace package. The primary's hoisted `node_modules/@scope/foo -> ../../packages/foo` is copied verbatim, dangles because the branch removed `packages/foo`, and is then repointed at `<primary>/packages/foo` — so an import the branch deleted still resolves, against code the branch does not have. A package the branch *adds* is deliberately handled the other way.

## Telling the two apart

The link cannot say which happened: `submodules/lib/packages/x` and `packages/x` alike sit under the worktree root and both exist in the primary. Where the **primary** resolves it can.

- Inside the primary checkout, outside any `node_modules` → content the branch owns, so only the worktree's own copy answers for it. Left dangling.
- Outside the checkout (through `submodules/<name>`) → the same real directory either checkout would reach, which is what makes the primary a stand-in at all. Repaired, as before.
- Inside the primary's `node_modules` → the installed store, which no branch adds to or deletes from. Repaired, so a non-hoisted (`.pnpm`) layout keeps working.

## Verified

Beyond the new unit test, on a real damo worktree created in `/tmp` (so `submodules/lib` genuinely dangles): every `@damienmortini/*` link still repairs to `/data/home/lib/packages/*` and `eslint` runs, while `@damo/slider-element` — a package present only in the primary — now stops resolving instead of silently reaching across. Diffing the link trees against `main`'s implementation shows three links newly left alone and none newly repaired.

## Tests

`packages/worktree-setup` 9/9 pass. The new test asserts the copied link is left exactly as copied, and covers the `.bin` entry pnpm gives a workspace package through its hoisted link — repointing that one would resolve the deleted package's code just as well. It fails on `main`'s behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMPmnMgJA1iD2pjzr1Atik