### PR TITLE
Let a worktree-setup change be verified from a consumer repo

### DIFF
--- a/packages/worktree-setup/README.md
+++ b/packages/worktree-setup/README.md
@@ -108,10 +108,10 @@ the adopter:
 node ~/lib-todo-42-something/packages/worktree-setup/src/cli.ts ~/damo-todo-7-other
 ```
 
-That bypasses nothing. The installed `.bin/worktree-setup` is a symlink to this same `src/cli.ts`,
-and an adopter contributes no code — only the `worktreeSetup` data read out of the worktree being
-set up — so the two runs differ in nothing but which file `node` was handed. Repeat it against a
-worktree of each adopter and the branch has been tried against all four real repositories.
+That bypasses nothing. The installed `.bin/worktree-setup` runs this same `src/cli.ts`, and an
+adopter contributes no code — only the `worktreeSetup` data read out of the worktree being set
+up — so the two runs differ in nothing but which file `node` was handed. Repeat it against a
+worktree of each adopter and the branch has been tried against every repository that uses it.
 
 ## Options
 

--- a/packages/worktree-setup/README.md
+++ b/packages/worktree-setup/README.md
@@ -96,6 +96,23 @@ source by path instead, which needs nothing installed anywhere:
 node ~/lib-todo-42-something/packages/worktree-setup/src/cli.ts ~/lib-todo-42-something
 ```
 
+## Verifying a change against an adopter
+
+The same form points an *adopter's* setup at an unmerged copy, which is the only way to try a
+change where a wrong verdict about submodules or link trees actually bites. `~/damo`'s
+`node_modules/.bin/worktree-setup` resolves through `submodules/lib` to the primary checkout, so
+it always runs `main`; hand `node` the branch's `cli.ts` instead and point it at a worktree of
+the adopter:
+
+```sh
+node ~/lib-todo-42-something/packages/worktree-setup/src/cli.ts ~/damo-todo-7-other
+```
+
+That bypasses nothing. The installed `.bin/worktree-setup` is a symlink to this same `src/cli.ts`,
+and an adopter contributes no code — only the `worktreeSetup` data read out of the worktree being
+set up — so the two runs differ in nothing but which file `node` was handed. Repeat it against a
+worktree of each adopter and the branch has been tried against all four real repositories.
+
 ## Options
 
 `directory` is the path the command is handed, defaulting to the working directory. The rest


### PR DESCRIPTION
Closes todo #199.

A branch of this package could not be exercised through a repository that actually uses it:
`~/damo/node_modules/.bin/worktree-setup` resolves through `submodules/lib` to the primary
checkout, so it always runs `main`. Verifying todo #188 against damo meant hand-rolling a
`node -e` import of the branch source and diffing the resulting link trees by hand.

The todo asked for an override — `WORKTREE_SETUP_ENTRY`, or `--setup-from <path>` in each
adopter's bootstrap script. That premise is stale: #189 dissolved those bootstrap scripts. No
adopter has a `script/worktree-setup.ts` any more, `.bin/worktree-setup` is a symlink to this
package's `src/cli.ts`, and an adopter contributes no code at all — only the `worktreeSetup`
data read out of the worktree being set up. Which copy runs is therefore already just which
file `node` is handed, and an env var would be a second way to select an entry point that is
already an argument.

Verified before writing it down — over the same damo worktree:

```
node ~/lib-todo-199-…/packages/worktree-setup/src/cli.ts ~/damo-tmp-199-verify
  → Linked 51 node_modules directories from /data/home/damo.
    3 copied link(s) dangle here and in /data/home/damo too, so they were left alone.

~/damo/node_modules/.bin/worktree-setup ~/damo-tmp-199-verify
  → identical output, byte-identical link tree (same md5 over `find node_modules -maxdepth 2`)
```

So the change is the one thing that was actually missing: the README now carries
"Verifying a change against an adopter". The todo's body has been corrected in place to
record the same finding.

`node --test src/*.test.ts` — 19/19 pass (documentation-only diff).