### PR TITLE
State the adoption shape in worktree-setup's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,31 @@
 # @damienmortini/lib
 Full of #astuce little helpers for the web.
 
+## Setting up a worktree
+
+A fresh worktree has to be linked against this checkout's installed dependencies, by
+[`@damienmortini/worktree-setup`](packages/worktree-setup) — its README covers what it does
+and what an adopting repository declares:
+
+```sh
+# from inside the fresh worktree, which has no node_modules to run anything through yet
+node packages/worktree-setup/src/cli.ts .
+```
+
+That is what the `worktree:setup` script is — the same entry point every adopter declares,
+pointed at this repository's own source rather than at the installed bin. This repository owns
+the package, so the installed copy is the primary checkout's, and a change to it could never
+be tested from a worktree of this repository. `src/cli.ts` imports nothing but `node:` builtins
+and its own module, so running it by path needs nothing installed anywhere — which is also why
+it is run from the worktree here, not from the primary as everywhere else.
+
+The link tree is where the setup stops. Some packages here still resolve to `dist` rather than
+to their source, so a change reaching across into one of those needs `pnpm run build` in the
+worktree on top; a change staying inside one package, whose own tests run its `src`, does not.
+
+No `resolvedLinkDirectories`: this repository has no `submodules/` at all — it is the one the
+others link *to*. `packageDirectories: ["packages"]` is where its own workspace packages live,
+and `requiredPackages` names the two configs every gate resolves through
+(`@damienmortini/eslint-config` and `@damienmortini/typescript-config`), so a worktree that
+cannot resolve them fails setup instead of failing `lint` later with a foreign error.
+

--- a/packages/worktree-setup/README.md
+++ b/packages/worktree-setup/README.md
@@ -67,6 +67,7 @@ worktree already carries.
 ```json
 {
   "devDependencies": { "@damienmortini/worktree-setup": "workspace:*" },
+  "scripts": { "worktree:setup": "worktree-setup" },
   "worktreeSetup": {
     "packageDirectories": ["packages"],
     "requiredPackages": ["@damienmortini/typescript-config", "@damienmortini/eslint-config"]
@@ -74,12 +75,30 @@ worktree already carries.
 }
 ```
 
-That is the whole adoption — the options this repository needs, and nothing else. A name the
-`worktreeSetup` key does not know is refused rather than ignored, because a repository states
-what it needs here and nowhere else now: a mistyped `packageDirectory` that silently asked for
-nothing would report a worktree ready that cannot run its own gates. JSON carries no comments,
-so a repository whose choice needs explaining — including the choice *not* to set an option —
-records that wherever it documents itself.
+Three entries and a prose section: that is the whole adoption, and none of the four is
+optional. `~/graph` is the worked example: its `package.json` carries those three as written
+above, and its `README.md` opens with the section described below.
+
+The `worktree:setup` script is the entry point the repository is asked for by name. Whoever
+sets up a worktree — an agent following the repository's own instructions — reads `scripts`
+and runs `pnpm run worktree:setup <worktree-path>`; the bin under `node_modules/.bin` is what
+that resolves to, not something a caller should have to know is installed. The alias is also
+where a repository that runs this differently puts the difference, so the entry point stays
+one name across all of them.
+
+A name the `worktreeSetup` key does not know is refused rather than ignored, because a
+repository states what it needs here and nowhere else now: a mistyped `packageDirectory` that
+silently asked for nothing would report a worktree ready that cannot run its own gates.
+
+JSON carries no comments, so the choices are recorded in prose, in the file the repository
+addresses its own readers from — `README.md` in `~/graph` and `~/damo`, `AGENTS.md` in
+`~/playground`. A section there says why each option is set *and why an unset one is unset*:
+`~/graph` records that it sets no `resolvedLinkDirectories` because none of its gates resolves
+through a submodule, and `~/playground` that it sets no `packageDirectories` because it owns no
+packages of its own. Without it the next reader finds an absence, which reads the same whether it was
+decided or forgotten, and re-derives the answer or changes it. The same section is where
+anything the repository does *on top of* the link tree belongs — `~/damo`'s build, in `~/damo`
+— because that step is the repository's, not this package's and not its caller's.
 
 `workspace:*` rather than a pinned version. This package is `private`, so it is never
 published; a pinned `0.0.0` would stop matching the first time `lerna version` bumps it and
@@ -95,6 +114,10 @@ source by path instead, which needs nothing installed anywhere:
 ```sh
 node ~/lib-todo-42-something/packages/worktree-setup/src/cli.ts ~/lib-todo-42-something
 ```
+
+That is what its `worktree:setup` alias runs — `node packages/worktree-setup/src/cli.ts`, from
+the worktree rather than from the primary, since the source to run is the branch's. The
+exception lives in the alias, which is why the entry point is still the same name here.
 
 ## Verifying a change against an adopter
 

--- a/packages/worktree-setup/README.md
+++ b/packages/worktree-setup/README.md
@@ -95,8 +95,8 @@ addresses its own readers from — `README.md` in `~/graph` and `~/damo`, `AGENT
 `~/playground`. A section there says why each option is set *and why an unset one is unset*:
 `~/graph` records that it sets no `resolvedLinkDirectories` because none of its gates resolves
 through a submodule, and `~/playground` that it sets no `packageDirectories` because it owns no
-packages of its own. Without it the next reader finds an absence, which reads the same whether it was
-decided or forgotten, and re-derives the answer or changes it. The same section is where
+packages of its own. Without it the next reader finds an absence, which reads the same whether
+it was decided or forgotten, and re-derives the answer or changes it. The same section is where
 anything the repository does *on top of* the link tree belongs — `~/damo`'s build, in `~/damo`
 — because that step is the repository's, not this package's and not its caller's.
 


### PR DESCRIPTION
Todo #201.

`packages/worktree-setup/README.md` documented the `worktreeSetup` key and the bin invocation, but not the shape an adopting repository is expected to take around them. Two conventions lived only as precedent in the repositories that adopted first: `~/graph` keeps `"worktree:setup": "worktree-setup"` as the in-repo entry point, and `~/graph` (README.md) and `~/playground` (AGENTS.md) each write a prose section recording why every option is set and why an unset one is unset.

Adopting `~/damo`, that gap cost a wrong reading — the alias looked like dead weight now that the bin exists and was deleted, and damo's build-on-top step went into the machine-wide `damo-worktree` skill instead of into damo. Nothing in the contract said otherwise; the README's one sentence about recording choices "wherever it documents itself" sat inside the options discussion and named no artifact.

"Using it from a repository" now states the whole adoption — devDependency, `worktreeSetup` key, `worktree:setup` alias, and a README/AGENTS.md section explaining the choices — with `~/graph` named as the worked example, and says that a repository's own on-top-of-the-link-tree step belongs in that section too. The `~/lib` exception paragraph gains the alias form it actually uses.

Documentation only; no code changed.