### PR TITLE
Link what the branch declares in worktree setup

### DIFF
--- a/packages/worktree-setup/README.md
+++ b/packages/worktree-setup/README.md
@@ -10,6 +10,18 @@ instead — every installed package symlinked across, scope directories and `.bi
 their original relative links, so workspace specifiers resolve to the worktree's own packages
 rather than the primary's, including packages the branch adds.
 
+The branch's tree is what the result is measured against, not the primary's. Workspace members
+come from the `packages` globs the worktree's own `pnpm-workspace.yaml` declares — including
+ones reached through submodule symlinks — as well as from `packageDirectories`, and every
+dependency declared by a manifest the worktree itself holds is verified to resolve from the
+package declaring it: linked from the primary's install where the mirror alone did not carry
+it, and refused loudly, naming the manifest and the name, where nothing can. (A member reached
+through a submodule symlink is a sibling checkout's shared directory: it gets its scope link,
+but its own dependencies are that repository's install to answer for, and nothing is ever
+written inside it.) A dependency the primary checkout has never installed anywhere cannot be
+linked from it, and reporting the tree ready anyway would be the wrong success — the failure
+says so instead.
+
 ## Driven from the primary checkout
 
 ```sh
@@ -134,7 +146,7 @@ repository states what it needs, and the package assumes nothing about who is ca
 
 | Option | |
 | --- | --- |
-| `packageDirectories` | Where this repository's own workspace packages live, e.g. `['packages']`. |
+| `packageDirectories` | Where this repository's own workspace packages live, e.g. `['packages']` — on top of the `packages` globs its `pnpm-workspace.yaml` declares, which are always read. |
 | `requiredPackages` | Names that must resolve once the tree is linked. |
 | `resolvedLinkDirectories` | Directories, e.g. `['submodules']`, whose committed symlinks must resolve. |
 

--- a/packages/worktree-setup/src/cli.test.ts
+++ b/packages/worktree-setup/src/cli.test.ts
@@ -34,7 +34,7 @@ test('reads the options the worktree declares, from the primary checkout', async
   const { status, stdout } = run([worktreeRoot], primaryRoot);
 
   assert.equal(status, 0);
-  assert.match(stdout, /Linked 1 node_modules directory/);
+  assert.match(stdout, /1 workspace package, 0 declared dependencies verified/);
   assert.equal(
     await fs.realpath(path.join(worktreeRoot, 'node_modules/@scope/added')),
     path.join(worktreeRoot, 'packages/added'),
@@ -45,10 +45,12 @@ test('mirrors the tree with no options at all, which a repository may legitimate
   const { primaryRoot, worktreeRoot } = await checkouts();
   await write(path.join(primaryRoot, 'node_modules/installed/index.js'), '');
 
-  const { status } = run([worktreeRoot], primaryRoot);
+  const { status, stdout } = run([worktreeRoot], primaryRoot);
 
   assert.equal(status, 0);
   assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/installed')), true);
+  // Even at zero members the line confirms the mirror ran, rather than reading as nothing done.
+  assert.match(stdout, /Linked the worktree against .*: 0 workspace packages/);
 });
 
 test('takes the working directory when handed no path, for a repository running its own copy', async () => {

--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -322,6 +322,20 @@ test('reports a copied link it could not repair, alongside what actually failed'
   );
 });
 
+test('refuses a dependency name that would point its link outside node_modules', async () => {
+  const { worktreeRoot } = await checkouts();
+
+  await write(
+    path.join(worktreeRoot, 'packages/app/package.json'),
+    '{"name":"@scope/app","dependencies":{"../../escapee":"1.0.0"}}',
+  );
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] }),
+    /declares an unusable dependency name/,
+  );
+});
+
 test('refuses a package name that would point the delete outside node_modules', async () => {
   const { primaryRoot, worktreeRoot } = await checkouts();
 

--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -101,6 +101,25 @@ test('refuses a pnpm-workspace.yaml shape it cannot read, rather than linking le
   await assert.rejects(setupWorktree({ directory: worktreeRoot }), /exclusion glob/);
 });
 
+test('refuses a glob that walks out of the worktree, wherever it is declared', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // A readable manifest right where the traversal would land, so a missed refusal would
+  // really link it.
+  await write(path.join(path.dirname(primaryRoot), 'outside/package.json'), '{"name":"@scope/outside"}');
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - \'../../outside\'\n');
+
+  await assert.rejects(setupWorktree({ directory: worktreeRoot }), /glob leaving the worktree/);
+  assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/@scope/outside')), false);
+
+  // The `packageDirectories` option comes from the same branch and walks the same way.
+  await fs.rm(path.join(worktreeRoot, 'pnpm-workspace.yaml'));
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, packageDirectories: ['..'] }),
+    /glob leaving the worktree/,
+  );
+});
+
 test('refuses a glob it cannot expand, rather than matching it against nothing', async () => {
   const { worktreeRoot } = await checkouts();
   await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - \'packages/web-*\'\n');

--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -148,6 +148,46 @@ test('skips a nameless fixture manifest a glob sweeps up, which pnpm links past 
   assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/@scope/real')), true);
 });
 
+test('does not read a configured root itself as a member, matching pnpm\'s trailing-`**`', async () => {
+  const { worktreeRoot } = await checkouts();
+
+  await write(path.join(worktreeRoot, 'packages/package.json'), '{"name":"@scope/root-manifest"}');
+  await write(path.join(worktreeRoot, 'packages/app/package.json'), '{"name":"@scope/app"}');
+
+  await setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] });
+
+  assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/@scope/app')), true);
+  assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/@scope/root-manifest')), false);
+});
+
+test('fails on a dependency the root manifest declares and nothing installs', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  await write(path.join(worktreeRoot, 'package.json'), '{"name":"repository","dependencies":{"absent-everywhere":"1.0.0"}}');
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot }),
+    (error: Error) => {
+      assert.match(error.message, new RegExp(`package.json declares absent-everywhere, which ${primaryRoot} has not installed`));
+      return true;
+    },
+  );
+});
+
+test('links a scoped declared dependency from a primary location the mirror does not cover', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  await write(path.join(primaryRoot, 'packages/node_modules/@scope/nested/index.js'), '');
+  await write(path.join(worktreeRoot, 'packages/app/package.json'), '{"name":"@scope/app","dependencies":{"@scope/nested":"^1.0.0"}}');
+
+  await setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] });
+
+  assert.equal(
+    await fs.realpath(path.join(worktreeRoot, 'packages/app/node_modules/@scope/nested')),
+    path.join(primaryRoot, 'packages/node_modules/@scope/nested'),
+  );
+});
+
 test('works without a root package.json, which a repository of pure submodules may not have', async () => {
   const { worktreeRoot } = await checkouts();
   await fs.rm(path.join(worktreeRoot, 'package.json'));

--- a/packages/worktree-setup/src/index.test.ts
+++ b/packages/worktree-setup/src/index.test.ts
@@ -56,6 +56,167 @@ test('links a package the branch adds, which the primary checkout knows nothing 
   assert.equal(existsSync(path.join(worktreeRoot, 'packages/added/node_modules/dependency')), true);
 });
 
+test('links the workspace members the worktree\'s own pnpm-workspace.yaml declares', async () => {
+  const { worktreeRoot } = await checkouts();
+
+  // Declared only in the yaml — no `packageDirectories` option names this root.
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - \'modules/*\'\n');
+  await write(path.join(worktreeRoot, 'modules/thing/package.json'), '{"name":"@scope/thing"}');
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  assert.equal(
+    await fs.realpath(path.join(worktreeRoot, 'node_modules/@scope/thing')),
+    path.join(worktreeRoot, 'modules/thing'),
+  );
+});
+
+test('links a workspace member behind a submodule symlink, without writing into the sibling', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // A sibling checkout both trees reach through a committed-shaped `submodules/<name>` link,
+  // holding a workspace member with an installed node_modules of its own.
+  const sibling = path.join(path.dirname(primaryRoot), 'sibling');
+  await write(path.join(sibling, 'packages/tool/package.json'), '{"name":"@scope/tool"}');
+  await write(path.join(sibling, 'packages/tool/node_modules/dependency/index.js'), '');
+  await fs.mkdir(path.join(worktreeRoot, 'submodules'), { recursive: true });
+  await fs.symlink('../../sibling', path.join(worktreeRoot, 'submodules/sibling'));
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - "submodules/*/packages/**"\n');
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  // The scope link exists and follows the worktree's own submodule path to the sibling.
+  assert.equal(
+    await fs.realpath(path.join(worktreeRoot, 'node_modules/@scope/tool')),
+    path.join(sibling, 'packages/tool'),
+  );
+  // The sibling's installed tree is shared and was not mirrored over.
+  assert.equal(existsSync(path.join(sibling, 'packages/tool/node_modules/dependency/index.js')), true);
+});
+
+test('refuses a pnpm-workspace.yaml shape it cannot read, rather than linking less than declared', async () => {
+  const { worktreeRoot } = await checkouts();
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - \'packages/**\'\n  - \'!packages/fixtures/**\'\n');
+
+  await assert.rejects(setupWorktree({ directory: worktreeRoot }), /exclusion glob/);
+});
+
+test('refuses a glob it cannot expand, rather than matching it against nothing', async () => {
+  const { worktreeRoot } = await checkouts();
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - \'packages/web-*\'\n');
+
+  await assert.rejects(setupWorktree({ directory: worktreeRoot }), /cannot expand/);
+});
+
+test('reads past comments inside the packages block, instead of ending it there', async () => {
+  const { worktreeRoot } = await checkouts();
+
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n# a flush-left note\n  - "modules/*"\n');
+  await write(path.join(worktreeRoot, 'modules/thing/package.json'), '{"name":"@scope/thing"}');
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/@scope/thing')), true);
+});
+
+test('follows a symlink inside a `**` glob, the way pnpm expands it', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  const sibling = path.join(path.dirname(primaryRoot), 'starred-sibling');
+  await write(path.join(sibling, 'packages/tool/package.json'), '{"name":"@scope/starred-tool"}');
+  await fs.mkdir(path.join(worktreeRoot, 'submodules'), { recursive: true });
+  await fs.symlink('../../starred-sibling', path.join(worktreeRoot, 'submodules/sibling'));
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - \'submodules/**\'\n');
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  assert.equal(
+    await fs.realpath(path.join(worktreeRoot, 'node_modules/@scope/starred-tool')),
+    path.join(sibling, 'packages/tool'),
+  );
+});
+
+test('skips a nameless fixture manifest a glob sweeps up, which pnpm links past too', async () => {
+  const { worktreeRoot } = await checkouts();
+
+  await write(path.join(worktreeRoot, 'pnpm-workspace.yaml'), 'packages:\n  - \'packages/**\'\n');
+  await write(path.join(worktreeRoot, 'packages/real/package.json'), '{"name":"@scope/real"}');
+  await write(path.join(worktreeRoot, 'packages/real/test/fixtures/package.json'), '{}');
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  assert.equal(existsSync(path.join(worktreeRoot, 'node_modules/@scope/real')), true);
+});
+
+test('works without a root package.json, which a repository of pure submodules may not have', async () => {
+  const { worktreeRoot } = await checkouts();
+  await fs.rm(path.join(worktreeRoot, 'package.json'));
+
+  await setupWorktree({ directory: worktreeRoot });
+
+  assert.equal(existsSync(path.join(worktreeRoot, 'node_modules')), true);
+});
+
+test('resolves a declared dependency through the mirrored tree', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  await write(path.join(primaryRoot, 'node_modules/installed/index.js'), '');
+  await write(path.join(worktreeRoot, 'packages/app/package.json'), '{"name":"@scope/app","dependencies":{"installed":"^1.0.0"}}');
+
+  await setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] });
+});
+
+test('fails naming a declared dependency the primary checkout has never installed', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // The branch adds a devDependency; the primary has no such edge anywhere. Mirroring alone
+  // used to report this tree linked, and the suite failed later in module resolution.
+  await write(path.join(worktreeRoot, 'packages/app/package.json'), '{"name":"@scope/app","devDependencies":{"jsdom":"^24.0.0"}}');
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] }),
+    (error: Error) => {
+      assert.match(error.message, new RegExp(`packages/app/package.json declares jsdom, which ${primaryRoot} has not installed`));
+      return true;
+    },
+  );
+});
+
+test('fails when a declared workspace member is one the branch deleted, instead of resolving the primary\'s copy', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // The primary still holds and links `@scope/gone`; the branch deleted the package but a
+  // manifest still declares it. Pointing at the primary would resolve code the branch removed.
+  await write(path.join(primaryRoot, 'packages/gone/package.json'), '{"name":"@scope/gone"}');
+  await fs.mkdir(path.join(primaryRoot, 'node_modules/@scope'), { recursive: true });
+  await fs.symlink('../../packages/gone', path.join(primaryRoot, 'node_modules/@scope/gone'));
+  await write(path.join(worktreeRoot, 'packages/app/package.json'), '{"name":"@scope/app","dependencies":{"@scope/gone":"workspace:*"}}');
+
+  await assert.rejects(
+    setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] }),
+    (error: Error) => {
+      assert.match(error.message, /packages\/app\/package.json declares @scope\/gone, which only .* own sources resolve/);
+      return true;
+    },
+  );
+});
+
+test('links a declared dependency from a primary location the mirror does not cover', async () => {
+  const { primaryRoot, worktreeRoot } = await checkouts();
+
+  // The package is the branch's own, so its primary-side directory does not exist and nothing
+  // nested was mirrored — but the name resolves in the primary partway up the walk.
+  await write(path.join(primaryRoot, 'packages/node_modules/dependency/index.js'), '');
+  await write(path.join(worktreeRoot, 'packages/app/package.json'), '{"name":"@scope/app","dependencies":{"dependency":"^1.0.0"}}');
+
+  await setupWorktree({ directory: worktreeRoot, packageDirectories: ['packages'] });
+
+  assert.equal(
+    await fs.realpath(path.join(worktreeRoot, 'packages/app/node_modules/dependency')),
+    path.join(primaryRoot, 'packages/node_modules/dependency'),
+  );
+});
+
 test('points a copied link that dangles here at the primary checkout', async () => {
   const { primaryRoot, worktreeRoot } = await checkouts();
 

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -250,12 +250,17 @@ async function expandWorkspaceGlob(worktreeRoot: string, glob: string): Promise<
     }
   }
 
+  const segments = glob.split('/');
   let matches = [''];
-  for (const segment of glob.split('/')) {
+  for (const [segmentIndex, segment] of segments.entries()) {
     const next = new Set<string>();
     for (const directory of matches) {
       if (segment === '**') {
-        next.add(directory);
+        // `**` matches zero or more segments in the middle of a glob (`a/**/b` matches
+        // `a/b`), but a trailing `**` matches only what is inside the directory, never the
+        // directory itself — `packages/**` must not read `packages` as a member, which is
+        // also what pnpm's own expansion does.
+        if (segmentIndex < segments.length - 1) next.add(directory);
         const seen = new Set([realpathSync(path.join(worktreeRoot, directory))]);
         for (const descendant of await descendantDirectories(worktreeRoot, directory, seen)) next.add(descendant);
       }
@@ -459,7 +464,7 @@ export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise
         continue;
       }
       await fs.mkdir(path.dirname(dependencyLink), { recursive: true });
-      await fs.rm(dependencyLink, { force: true });
+      await fs.rm(dependencyLink, { recursive: true, force: true });
       await fs.symlink(target, dependencyLink);
     }
   }

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -488,7 +488,7 @@ export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise
     // installed off to move a worktree that was never in the wrong place — a confident wrong
     // diagnosis, which is worse than none at all and is exactly what this package exists to
     // stop repeating.
-    if ((missingPackages.length > 0 || danglingLinks.length > 0) && (unrepaired.length > 0 || danglingLinks.length > 0)) {
+    if (danglingLinks.length > 0 || (missingPackages.length > 0 && unrepaired.length > 0)) {
       reasons.push(`Links committed as \`../../<name>\` resolve only for a checkout sitting directly under ${path.dirname(primaryRoot)} — and this worktree is at ${worktreeRoot}. Create it there instead: \`git worktree add ${path.join(path.dirname(primaryRoot), '<name>')}\`.`);
     }
     throw new Error(reasons.join('\n'));

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -245,6 +245,15 @@ async function expandWorkspaceGlob(worktreeRoot: string, glob: string): Promise<
   // Checked before expanding anything, so the refusal cannot be skipped by an earlier
   // segment matching no directory at all.
   for (const segment of glob.split('/')) {
+    // A glob comes from the worktree being set up — often somebody else's branch, checked
+    // out to review it — and its literal segments feed `path.join`, which collapses `..`.
+    // Contained the same way a manifest's name is: a walk that leaves the worktree would
+    // link members from anywhere the user can read. A committed symlink pointing outside is
+    // still followed — reaching outside is what it is for, and it is content the repository
+    // itself holds.
+    if (segment === '' || segment === '.' || segment === '..') {
+      throw new Error(`pnpm-workspace.yaml declares a glob leaving the worktree (${glob}), which this setup does not support.`);
+    }
     if (segment !== '*' && segment !== '**' && /[*?[\]{}]/.test(segment)) {
       throw new Error(`pnpm-workspace.yaml declares a glob this setup cannot expand (${glob}) — only literal path segments, \`*\`, and \`**\` are supported.`);
     }

--- a/packages/worktree-setup/src/index.ts
+++ b/packages/worktree-setup/src/index.ts
@@ -8,13 +8,21 @@
 // specifiers resolve to the worktree's own packages rather than the primary checkout's —
 // including packages the branch adds, which the primary checkout knows nothing about.
 //
+// The branch's own tree is the measure of the result, not the primary's. Workspace members
+// come from the globs the worktree's pnpm-workspace.yaml declares as well as the
+// `packageDirectories` option, and every dependency declared by a manifest the worktree
+// itself holds — the root and the members not reached through submodule links, whose own
+// dependencies are their sibling checkout's install to answer for — is then verified to
+// resolve: linked from the primary's install where the mirror alone did not carry it, and
+// refused loudly, naming the manifest and the name, where nothing can.
+//
 // One copy, every repository that uses it. Everything below is the same everywhere; what
 // differs between them is passed in as options, so a fix lands once rather than being
 // re-derived per repository — which is how the per-repository copies drifted apart in the
 // first place.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -24,7 +32,9 @@ export interface WorktreeSetupOptions {
   /**
    * Directories holding workspace packages, relative to the worktree root — `packages` for
    * a repository that has its own, nothing for one whose packages all come from submodules.
-   * Missing directories are skipped, so a branch may add or drop one.
+   * Missing directories are skipped, so a branch may add or drop one. The `packages` globs
+   * of the worktree's own `pnpm-workspace.yaml` are always walked as well, so this option
+   * is only for roots that file does not declare.
    */
   packageDirectories?: string[];
   /**
@@ -142,10 +152,7 @@ async function repairDanglingLinks(copiedLinks: string[], worktreeRoot: string, 
       continue;
     }
     const primaryTarget = realpathSync(primaryPath);
-    const fromPrimaryRoot = path.relative(primaryRoot, primaryTarget).split(path.sep);
-    // Inside the checkout and outside any node_modules: content of the branch's own, which
-    // only the worktree's copy can answer for.
-    if (fromPrimaryRoot[0] !== '..' && !fromPrimaryRoot.includes('node_modules')) continue;
+    if (isCheckoutOwnContent(primaryRoot, primaryTarget)) continue;
     await fs.rm(link, { force: true });
     await fs.symlink(primaryTarget, link);
   }
@@ -154,24 +161,150 @@ async function repairDanglingLinks(copiedLinks: string[], worktreeRoot: string, 
 }
 
 /**
- * Directories holding a package.json under `directory`, relative to the worktree root.
- *
- * The walk carries on past a package it finds rather than stopping there, because pnpm's
- * `packages/**` glob matches a package nested inside another one. None of the repositories
- * using this has such a package today, which is exactly why a shallow scan would look
- * correct here — and would then quietly stop linking the first nested package somebody adds.
+ * Inside the checkout and outside any node_modules: content of the branch's own, which
+ * only the worktree's copy can answer for — the primary must never stand in for it.
  */
-async function findPackageDirectories(worktreeRoot: string, directory: string): Promise<string[]> {
-  const directories: string[] = [];
+function isCheckoutOwnContent(primaryRoot: string, target: string): boolean {
+  const fromPrimaryRoot = path.relative(primaryRoot, target).split(path.sep);
+  return fromPrimaryRoot[0] !== '..' && !fromPrimaryRoot.includes('node_modules');
+}
 
-  for (const entry of await fs.readdir(path.join(worktreeRoot, directory), { withFileTypes: true })) {
-    if (!entry.isDirectory() || entry.name === 'node_modules' || entry.name === 'dist') continue;
-    const child = path.join(directory, entry.name);
-    if (existsSync(path.join(worktreeRoot, child, 'package.json'))) directories.push(child);
-    directories.push(...await findPackageDirectories(worktreeRoot, child));
+interface PackageManifest {
+  name?: unknown;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+/** The parsed package.json at `manifestPath` under `worktreeRoot`, failing with the file named rather than a bare parse error reporting a position in a file it never mentions. */
+async function readManifest(worktreeRoot: string, manifestPath: string): Promise<PackageManifest> {
+  try {
+    return JSON.parse(await fs.readFile(path.join(worktreeRoot, manifestPath), 'utf8'));
+  }
+  catch (error) {
+    throw new Error(`Cannot read ${manifestPath} in ${worktreeRoot}: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+  }
+}
+
+/**
+ * The `packages` globs of the worktree's own `pnpm-workspace.yaml`, or nothing when the
+ * repository has none. Parsed by hand and only this one block of it, because this package
+ * must resolve nothing to run — the bootstrap path executes it with nothing installed in any
+ * checkout, so a YAML dependency is not an option. Shapes the narrow parser cannot read are
+ * refused rather than skipped: a glob dropped silently would link a tree the workspace never
+ * declared and report it ready.
+ */
+async function workspacePackageGlobs(worktreeRoot: string): Promise<string[]> {
+  const filePath = path.join(worktreeRoot, 'pnpm-workspace.yaml');
+  if (!existsSync(filePath)) return [];
+
+  const globs: string[] = [];
+  let inPackagesBlock = false;
+  for (const line of (await fs.readFile(filePath, 'utf8')).split('\n')) {
+    // Comments and document markers carry nothing and end nothing — a flush-left `#` inside
+    // the block must not read as the next top-level key and silently drop the globs after it.
+    if (/^\s*#/.test(line) || /^---\s*$/.test(line)) continue;
+    const packagesKey = line.match(/^(?:packages|'packages'|"packages")\s*:(.*)$/);
+    if (packagesKey) {
+      if (packagesKey[1].replace(/#.*$/, '').trim() !== '') {
+        throw new Error(`${filePath} declares \`packages\` in a form this setup cannot read — use a block list of globs, one \`- \` line each.`);
+      }
+      inPackagesBlock = true;
+      continue;
+    }
+    if (!inPackagesBlock) continue;
+    const item = line.match(/^\s*-\s+(?:'([^']*)'|"([^"]*)"|([^#]+))/);
+    if (item) {
+      const glob = (item[1] ?? item[2] ?? item[3]).trim();
+      if (glob.startsWith('!')) {
+        throw new Error(`${filePath} declares an exclusion glob (${glob}), which this setup does not support.`);
+      }
+      globs.push(glob);
+    }
+    else if (/^\S/.test(line)) {
+      inPackagesBlock = false;
+    }
+  }
+  return globs;
+}
+
+/** Installed, built, and hidden trees, which no walk here descends — one list for every walker, so which source declared a root cannot change which members it finds. */
+function isSkippedDirectoryName(name: string): boolean {
+  return name === 'node_modules' || name === 'dist' || name.startsWith('.');
+}
+
+/**
+ * Directories under `worktreeRoot` matching one workspace glob and holding a package.json,
+ * relative to the worktree root. Every segment follows symlinks, because that is what a
+ * workspace root reached through a committed submodule link is — the very members a plain
+ * directory walk cannot see — with `**` carrying a seen-set so a symlink cycle cannot
+ * recurse forever. A glob shape this cannot expand (`web-*`, `pkg?`, `{a,b}`) is refused
+ * rather than matched against nothing: a silently empty expansion would link a worktree
+ * with fewer members than the workspace declares and report it ready.
+ */
+async function expandWorkspaceGlob(worktreeRoot: string, glob: string): Promise<string[]> {
+  // Checked before expanding anything, so the refusal cannot be skipped by an earlier
+  // segment matching no directory at all.
+  for (const segment of glob.split('/')) {
+    if (segment !== '*' && segment !== '**' && /[*?[\]{}]/.test(segment)) {
+      throw new Error(`pnpm-workspace.yaml declares a glob this setup cannot expand (${glob}) — only literal path segments, \`*\`, and \`**\` are supported.`);
+    }
   }
 
-  return directories;
+  let matches = [''];
+  for (const segment of glob.split('/')) {
+    const next = new Set<string>();
+    for (const directory of matches) {
+      if (segment === '**') {
+        next.add(directory);
+        const seen = new Set([realpathSync(path.join(worktreeRoot, directory))]);
+        for (const descendant of await descendantDirectories(worktreeRoot, directory, seen)) next.add(descendant);
+      }
+      else if (segment === '*') {
+        for (const entry of await fs.readdir(path.join(worktreeRoot, directory), { withFileTypes: true })) {
+          if (isSkippedDirectoryName(entry.name)) continue;
+          const child = path.join(directory, entry.name);
+          if (statSync(path.join(worktreeRoot, child), { throwIfNoEntry: false })?.isDirectory()) next.add(child);
+        }
+      }
+      else {
+        const child = path.join(directory, segment);
+        if (statSync(path.join(worktreeRoot, child), { throwIfNoEntry: false })?.isDirectory()) next.add(child);
+      }
+    }
+    matches = [...next];
+  }
+  return matches.filter(directory => directory !== '' && existsSync(path.join(worktreeRoot, directory, 'package.json')));
+}
+
+/** Every directory below `directory`, symlinks followed, each real path descended once. */
+async function descendantDirectories(worktreeRoot: string, directory: string, seen: Set<string>): Promise<string[]> {
+  const descendants: string[] = [];
+  for (const entry of await fs.readdir(path.join(worktreeRoot, directory), { withFileTypes: true })) {
+    if (isSkippedDirectoryName(entry.name)) continue;
+    const child = path.join(directory, entry.name);
+    const childPath = path.join(worktreeRoot, child);
+    if (!statSync(childPath, { throwIfNoEntry: false })?.isDirectory()) continue;
+    const realChildPath = realpathSync(childPath);
+    if (seen.has(realChildPath)) continue;
+    seen.add(realChildPath);
+    descendants.push(child, ...await descendantDirectories(worktreeRoot, child, seen));
+  }
+  return descendants;
+}
+
+/**
+ * Where `name` resolves walking up from `packageDirectory` the way node does — the nearest
+ * `node_modules/<name>` between the package and the checkout root — or nothing. Existence is
+ * the criterion, same as `requiredPackages`: what a linked tree can answer for.
+ */
+function resolveThroughCheckout(checkoutRoot: string, packageDirectory: string, name: string): string | undefined {
+  let directory = path.join(checkoutRoot, packageDirectory);
+  while (true) {
+    const candidate = path.join(directory, 'node_modules', name);
+    if (existsSync(candidate)) return candidate;
+    if (directory === checkoutRoot) return undefined;
+    directory = path.dirname(directory);
+  }
 }
 
 /** The symlinks directly inside `directory` that do not resolve, relative to the worktree root. */
@@ -211,56 +344,124 @@ export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise
 
   const copiedLinks: string[] = [];
   await materialize(path.join(primaryRoot, 'node_modules'), path.join(worktreeRoot, 'node_modules'), copiedLinks);
-  let linked = 1;
 
-  // The worktree's own packages drive this, not the primary checkout's: a package added on
+  // The worktree's own manifests drive this, not the primary checkout's: a package added on
   // the branch exists in neither the primary's tree nor its hoisted scope, and used to be
   // the one thing still linked by hand. Resolving to the primary instead is
   // also what silently breaks a dev server that serves the worktree — a package reached
-  // through a path outside that root renders as a blank element.
+  // through a path outside that root renders as a blank element. Membership is the union of
+  // the `packageDirectories` walk and the globs the worktree's own pnpm-workspace.yaml
+  // declares, because the yaml is where a workspace states its roots — a member under a
+  // `submodules/*` glob is one the hand-kept option never named.
+  const workspacePackageDirectories = new Set<string>();
   for (const packageRoot of packageDirectories) {
-    if (!existsSync(path.join(worktreeRoot, packageRoot))) continue;
+    // The option names a root to scan whole, which is the `**` expansion of it — one walker
+    // for both sources, so which one declared a root cannot change which members it finds.
+    for (const packageDirectory of await expandWorkspaceGlob(worktreeRoot, `${packageRoot}/**`)) {
+      workspacePackageDirectories.add(packageDirectory);
+    }
+  }
+  for (const glob of await workspacePackageGlobs(worktreeRoot)) {
+    for (const packageDirectory of await expandWorkspaceGlob(worktreeRoot, glob)) {
+      workspacePackageDirectories.add(packageDirectory);
+    }
+  }
 
-    for (const packageDirectory of await findPackageDirectories(worktreeRoot, packageRoot)) {
+  // The members whose content is the worktree's own, each carrying its parsed manifest for
+  // the dependency check below. One reached through a submodule symlink is a sibling
+  // checkout's real directory — shared with every other checkout and installed by that
+  // repository itself — so it gets its scope link but nothing may be written inside it:
+  // mirroring a node_modules into it would delete the sibling's installed tree, and its
+  // declared dependencies are that repository's own install to answer for.
+  const ownManifests: { directory: string; manifest: PackageManifest }[] = [];
+  let workspacePackageCount = 0;
+
+  for (const packageDirectory of workspacePackageDirectories) {
+    const manifest = await readManifest(worktreeRoot, path.join(packageDirectory, 'package.json'));
+    const { name } = manifest;
+    // No name at all is no workspace member pnpm could link either — a test fixture, most
+    // often, and the always-read workspace globs sweep those up. Skipped, not refused: pnpm
+    // itself links past them.
+    if (name === undefined) continue;
+
+    const modulesRoot = path.join(worktreeRoot, 'node_modules');
+    const scopedLink = typeof name === 'string' ? path.join(modulesRoot, name) : '';
+    // `name` is whatever the branch being set up wrote in a package.json, and two lines
+    // below it drives a recursive forced delete. `path.join` collapses `..`, so a name
+    // spelled to climb out of the tree would aim that delete anywhere the user can write —
+    // and a worktree is often somebody else's branch, checked out to review it. Contained
+    // here rather than trusted.
+    if (!scopedLink.startsWith(modulesRoot + path.sep)) {
+      throw new Error(`${packageDirectory}/package.json declares an unusable name (${JSON.stringify(name)}): the workspace link it asks for would land outside ${modulesRoot}.`);
+    }
+
+    workspacePackageCount++;
+    if (realpathSync(path.join(worktreeRoot, packageDirectory)).startsWith(worktreeRoot + path.sep)) {
+      ownManifests.push({ directory: packageDirectory, manifest });
       const nestedModules = path.join(primaryRoot, packageDirectory, 'node_modules');
       if (existsSync(nestedModules)) {
         // pnpm nests what it cannot hoist — a version conflict, and the workspace links
         // between sibling packages, which are relative and so follow the worktree's own
         // sources across.
         await materialize(nestedModules, path.join(worktreeRoot, packageDirectory, 'node_modules'), copiedLinks);
-        linked++;
       }
-
-      const { name } = JSON.parse(await fs.readFile(path.join(worktreeRoot, packageDirectory, 'package.json'), 'utf8'));
-      const modulesRoot = path.join(worktreeRoot, 'node_modules');
-      const scopedLink = typeof name === 'string' ? path.join(modulesRoot, name) : '';
-      // `name` is whatever the branch being set up wrote in a package.json, and two lines
-      // below it drives a recursive forced delete. `path.join` collapses `..`, so a name
-      // spelled to climb out of the tree would aim that delete anywhere the user can write —
-      // and a worktree is often somebody else's branch, checked out to review it. Contained
-      // here rather than trusted, and the same check catches a package.json with no name at
-      // all, which a stray fixture under `packageDirectories` can perfectly well be.
-      if (!scopedLink.startsWith(modulesRoot + path.sep)) {
-        throw new Error(`${packageDirectory}/package.json declares an unusable name (${JSON.stringify(name)}): the workspace link it asks for would land outside ${modulesRoot}.`);
-      }
-      await fs.mkdir(path.dirname(scopedLink), { recursive: true });
-      await fs.rm(scopedLink, { recursive: true, force: true });
-      await fs.symlink(path.relative(path.dirname(scopedLink), path.join(worktreeRoot, packageDirectory)), scopedLink);
     }
+
+    await fs.mkdir(path.dirname(scopedLink), { recursive: true });
+    await fs.rm(scopedLink, { recursive: true, force: true });
+    await fs.symlink(path.relative(path.dirname(scopedLink), path.join(worktreeRoot, packageDirectory)), scopedLink);
   }
 
   const unrepaired = await repairDanglingLinks(copiedLinks, worktreeRoot, primaryRoot);
 
-  console.log(`Linked ${linked} node_modules ${linked === 1 ? 'directory' : 'directories'} from ${primaryRoot}.`);
+  // Every dependency the branch's own manifests declare must resolve from the package that
+  // declares it, checked rather than assumed: mirroring covers only edges the primary has
+  // installed, and a hoisted store happening to hold a name is not the same as the tree
+  // honouring what the branch wrote. Peer and optional dependencies stay out of it — peers
+  // resolve from whoever consumes the package, and optional ones are declared as allowed to
+  // be absent.
+  const unresolvableDependencies: string[] = [];
+  let declaredDependencyCount = 0;
+  // The root manifest joins the members: a branch can add a root devDependency the same way.
+  // Its absence is legitimate for a repository whose packages all come from elsewhere, so it
+  // is skipped rather than required.
+  const checkedManifests = [...ownManifests];
+  if (existsSync(path.join(worktreeRoot, 'package.json'))) {
+    checkedManifests.unshift({ directory: '', manifest: await readManifest(worktreeRoot, 'package.json') });
+  }
+  for (const { directory: manifestDirectory, manifest } of checkedManifests) {
+    const manifestPath = path.join(manifestDirectory, 'package.json');
+    const declaredNames = new Set([
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.devDependencies ?? {}),
+    ]);
 
-  // Said out loud rather than left to the failure below, which only mentions these when
-  // something else went wrong at the same time. Not a failure on its own: a link reaches
-  // this list by dangling in the primary checkout too — a stale `.bin` entry pnpm left
-  // behind, most of the time — so the worktree is no worse off than the tree it mirrors,
-  // and failing over it would blame the branch for the state of the checkout beside it.
-  // Worth a line all the same, because it is the answer when something later will not run.
-  if (unrepaired.length > 0) {
-    console.log(`${unrepaired.length} copied link(s) dangle here and in ${primaryRoot} too, so they were left alone.`);
+    for (const name of declaredNames) {
+      declaredDependencyCount++;
+      // The same containment the workspace-link delete gets: `name` is a manifest's word,
+      // and below it decides where a link is written.
+      const declaringModules = path.join(worktreeRoot, manifestDirectory, 'node_modules');
+      const dependencyLink = path.join(declaringModules, name);
+      if (!dependencyLink.startsWith(declaringModules + path.sep)) {
+        unresolvableDependencies.push(`${manifestPath} declares an unusable dependency name (${JSON.stringify(name)}).`);
+        continue;
+      }
+      if (resolveThroughCheckout(worktreeRoot, manifestDirectory, name)) continue;
+
+      const primaryCandidate = resolveThroughCheckout(primaryRoot, manifestDirectory, name);
+      if (!primaryCandidate) {
+        unresolvableDependencies.push(`${manifestPath} declares ${name}, which ${primaryRoot} has not installed anywhere — the primary checkout's install is the only store this setup links from.`);
+        continue;
+      }
+      const target = realpathSync(primaryCandidate);
+      if (isCheckoutOwnContent(primaryRoot, target)) {
+        unresolvableDependencies.push(`${manifestPath} declares ${name}, which only ${primaryRoot}'s own sources resolve — this branch does not have that package.`);
+        continue;
+      }
+      await fs.mkdir(path.dirname(dependencyLink), { recursive: true });
+      await fs.rm(dependencyLink, { force: true });
+      await fs.symlink(target, dependencyLink);
+    }
   }
 
   const missingPackages = requiredPackages.filter(name => !existsSync(path.join(worktreeRoot, 'node_modules', name)));
@@ -268,11 +469,14 @@ export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise
 
   // Reported together when they happen together: they share a cause, and fixing where the
   // worktree lives fixes both at once.
-  if (missingPackages.length > 0 || danglingLinks.length > 0) {
-    const reasons: string[] = [];
+  if (unresolvableDependencies.length > 0 || missingPackages.length > 0 || danglingLinks.length > 0) {
+    const reasons: string[] = [...unresolvableDependencies];
     if (missingPackages.length > 0) {
       reasons.push(`Cannot resolve ${missingPackages.join(' or ')} from ${worktreeRoot}.`);
     }
+    // Evidence on every failure: a stale link that dangles in the primary too can be the
+    // very reason a declared name reads as never installed, so the reader gets the count
+    // whatever else went wrong.
     if (unrepaired.length > 0) {
       reasons.push(`${unrepaired.length} copied link(s) could not be pointed at the primary checkout either.`);
     }
@@ -280,12 +484,30 @@ export async function setupWorktree(options: WorktreeSetupOptions = {}): Promise
       reasons.push(`${danglingLinks.join(' and ')} dangle from here, and repairing node_modules does not repair the tracked links themselves.`);
     }
     // Where the worktree lives is the answer to a link that dangles, and only to that. Said
-    // unconditionally it would send a reader whose package is merely not installed off to
-    // move a worktree that was never in the wrong place — a confident wrong diagnosis, which
-    // is worse than none at all and is exactly what this package exists to stop repeating.
-    if (unrepaired.length > 0 || danglingLinks.length > 0) {
+    // on a dependency-only failure it would send a reader whose package is merely not
+    // installed off to move a worktree that was never in the wrong place — a confident wrong
+    // diagnosis, which is worse than none at all and is exactly what this package exists to
+    // stop repeating.
+    if ((missingPackages.length > 0 || danglingLinks.length > 0) && (unrepaired.length > 0 || danglingLinks.length > 0)) {
       reasons.push(`Links committed as \`../../<name>\` resolve only for a checkout sitting directly under ${path.dirname(primaryRoot)} — and this worktree is at ${worktreeRoot}. Create it there instead: \`git worktree add ${path.join(path.dirname(primaryRoot), '<name>')}\`.`);
     }
     throw new Error(reasons.join('\n'));
+  }
+
+  // Counted from the branch's tree — the workspace members its checkout holds and the
+  // dependencies its manifests declare — not from how much of the primary was mirrored,
+  // which says nothing about whether this worktree resolves what it needs. Opening with the
+  // mirror keeps a repository with no members of its own from reading its own success as
+  // nothing done.
+  console.log(`Linked the worktree against ${primaryRoot}'s install: ${workspacePackageCount} workspace package${workspacePackageCount === 1 ? '' : 's'}, ${declaredDependencyCount === 1 ? '1 declared dependency' : `${declaredDependencyCount} declared dependencies`} verified.`);
+
+  // Said out loud rather than left to a failure, which only mentions these when something
+  // else went wrong at the same time. Not a failure on its own: a link reaches this list by
+  // dangling in the primary checkout too — a stale `.bin` entry pnpm left behind, most of
+  // the time — so the worktree is no worse off than the tree it mirrors, and failing over it
+  // would blame the branch for the state of the checkout beside it. Worth a line all the
+  // same, because it is the answer when something later will not run.
+  if (unrepaired.length > 0) {
+    console.log(`${unrepaired.length} copied link(s) dangle here and in ${primaryRoot} too, so they were left alone.`);
   }
 }


### PR DESCRIPTION
worktree-setup mirrored the primary's installed tree and reported its count as success, so a devDependency added on a branch got no link (resolving only by hoisting luck), and workspace members under `pnpm-workspace.yaml` globs — submodule roots included — were never linked from the worktree's own sources.

- Workspace membership is the union of `packageDirectories` and the worktree's own `pnpm-workspace.yaml` `packages` globs, expanded by a symlink-following walker; unsupported glob shapes are refused loudly instead of matching nothing.
- Every dependency declared by a manifest the worktree itself holds is verified to resolve from the declaring package: linked through the primary's install where the mirror did not carry it, failed by name where nothing can (including a workspace member the branch deleted).
- Members reached through submodule symlinks get their scope link but are never written into — they are shared sibling checkouts.
- The success line counts the branch's tree (members linked, declared dependencies verified), not mirrored primary directories, and prints only after all checks pass.

Verified against this repository's own worktree (65 packages / 95 dependencies) and against worktrees of every adopting repository, plus the original reproduction — a dependency the primary never installed now fails naming the manifest and the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWxwPPFRFNTmKZpRNgGWpQ