### PR TITLE
Run the test gate in CI on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+# `npm test` is this repository's gate: eslint over `packages`, a typecheck of every
+# package tsconfig, and each package's own suite. Nothing ran it on a pull request before
+# this job, so a lint or type error was caught only by whoever next ran the gate on their
+# own machine — the accumulation path that once left 532 eslint errors to clear in one go.
+name: Tests
+
+# No `push: branches: [main]` — every merge squashes a branch this job already passed on.
+# No `paths-ignore` either: a skipped workflow reports no check at all rather than a
+# neutral success, so filtering docs-only pull requests would leave nothing for a required
+# status check to wait on. The concurrency cancel below is where the real spend is saved.
+on: pull_request
+
+# A review round pushes while the previous push's run is still going; only the newest head
+# can merge, so the superseded run is pure spend.
+concurrency:
+  group: tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      # Pinned rather than left to the runner default: packages import TypeScript source
+      # directly and are typechecked against the syntax the current Node runs natively.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Before the gate, not part of it: packages point `types` at `dist/index.d.ts`, so
+      # the typecheck resolves a sibling workspace package's types from its built output.
+      - run: pnpm run build
+
+      - run: npm test


### PR DESCRIPTION
Adds `.github/workflows/test.yml`: on every pull request, install frozen, `pnpm run build`, then `npm test`.

`npm test` is eslint over `packages`, a typecheck of every package tsconfig, and each package's own suite. Until now nothing ran it on a pull request, so a reintroduced lint or type error was caught only by whoever next ran the gate locally.

The build runs before the gate rather than as part of it: packages point `types` at `dist/index.d.ts`, so the typecheck resolves a sibling workspace package's types from its built output.

Verified locally on this branch — cold `pnpm run build`, then `npm test` green end to end.

Deliberately left alone:
- `lockfile.yml` keeps its own job. This workflow's frozen install covers the same ground, but an independent fast signal for "is the lockfile current" is worth one cheap runner.
- The root `test` script lints `packages`, while `lint` lints `.` — so `eslint.config.js`, `rewritepackagefiles.js` and `web-dev-server.config.js` stay outside this gate. Widening the script is a separate change.