### PR TITLE
Keep workspace packages linked across version bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es-module-shims": "^2.8.1"
   },
   "devDependencies": {
-    "@damienmortini/eslint-config": "0.0.32",
+    "@damienmortini/eslint-config": "workspace:*",
     "@damienmortini/server": "workspace:^",
     "@damienmortini/typescript-config": "workspace:^",
     "@damienmortini/worktree-setup": "workspace:*",

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -20,7 +20,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@damienmortini/ticker": "0.0.18"
+    "@damienmortini/ticker": "workspace:*"
   },
   "devDependencies": {
     "typescript": "6.0.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,8 +22,8 @@
   "author": "Damien Mortini",
   "type": "module",
   "dependencies": {
-    "@damienmortini/gesture-observer": "0.0.10",
-    "@damienmortini/math": "0.0.28"
+    "@damienmortini/gesture-observer": "workspace:*",
+    "@damienmortini/math": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/damdom/damdom-colorpicker/package.json
+++ b/packages/damdom/damdom-colorpicker/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/math": "0.0.28"
+    "@damienmortini/math": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/damdom/damdom-glslcanvas/package.json
+++ b/packages/damdom/damdom-glslcanvas/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/webgl": "0.0.42"
+    "@damienmortini/webgl": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/damdom/damdom-gui/package.json
+++ b/packages/damdom/damdom-gui/package.json
@@ -20,11 +20,11 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/damdom-checkbox": "0.0.7",
-    "@damienmortini/damdom-colorpicker": "0.0.42",
-    "@damienmortini/damdom-select": "0.0.7",
-    "@damienmortini/damdom-slider": "0.0.7",
-    "@damienmortini/damdom-textfield": "0.0.7"
+    "@damienmortini/damdom-checkbox": "workspace:*",
+    "@damienmortini/damdom-colorpicker": "workspace:*",
+    "@damienmortini/damdom-select": "workspace:*",
+    "@damienmortini/damdom-slider": "workspace:*",
+    "@damienmortini/damdom-textfield": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/damdom/damdom-ticker/package.json
+++ b/packages/damdom/damdom-ticker/package.json
@@ -22,7 +22,7 @@
     "generateTypes": "npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly"
   },
   "dependencies": {
-    "@damienmortini/ticker": "0.0.18"
+    "@damienmortini/ticker": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/damdom/damdom-viewport/package.json
+++ b/packages/damdom/damdom-viewport/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/core": "0.2.163"
+    "@damienmortini/core": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/demo/demo-webgl/package.json
+++ b/packages/demo/demo-webgl/package.json
@@ -14,10 +14,10 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/core": "0.2.163",
-    "@damienmortini/damdom-ticker": "0.0.51",
-    "@damienmortini/math": "0.0.28",
-    "@damienmortini/webgl": "0.0.42"
+    "@damienmortini/core": "workspace:*",
+    "@damienmortini/damdom-ticker": "workspace:*",
+    "@damienmortini/math": "workspace:*",
+    "@damienmortini/webgl": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/element/animation-sprite/package.json
+++ b/packages/element/animation-sprite/package.json
@@ -18,8 +18,8 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/core": "0.2.163",
-    "@damienmortini/damdom-ticker": "0.0.51"
+    "@damienmortini/core": "workspace:*",
+    "@damienmortini/damdom-ticker": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/element/animation-view/package.json
+++ b/packages/element/animation-view/package.json
@@ -19,7 +19,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/core": "0.2.163"
+    "@damienmortini/core": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/element/input-joystick/package.json
+++ b/packages/element/input-joystick/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/core": "0.2.163"
+    "@damienmortini/core": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/element/input-knob/package.json
+++ b/packages/element/input-knob/package.json
@@ -24,10 +24,10 @@
     "test": "node --test --import ./test/setup.ts"
   },
   "devDependencies": {
-    "@damienmortini/test-support": "0.0.1",
+    "@damienmortini/test-support": "workspace:*",
     "jsdom": "^29.1.1"
   },
   "dependencies": {
-    "@damienmortini/math": "^0.0.28"
+    "@damienmortini/math": "workspace:^"
   }
 }

--- a/packages/element/input-number/package.json
+++ b/packages/element/input-number/package.json
@@ -24,7 +24,7 @@
     "test": "node --test --import ./test/setup.ts"
   },
   "devDependencies": {
-    "@damienmortini/test-support": "0.0.1",
+    "@damienmortini/test-support": "workspace:*",
     "jsdom": "^29.1.1"
   }
 }

--- a/packages/element/input-ruler/package.json
+++ b/packages/element/input-ruler/package.json
@@ -24,10 +24,10 @@
     "test": "node --test --import ./test/setup.ts"
   },
   "devDependencies": {
-    "@damienmortini/test-support": "0.0.1",
+    "@damienmortini/test-support": "workspace:*",
     "jsdom": "^29.1.1"
   },
   "dependencies": {
-    "@damienmortini/ticker": "^0.0.18"
+    "@damienmortini/ticker": "workspace:^"
   }
 }

--- a/packages/element/input-signal-array/package.json
+++ b/packages/element/input-signal-array/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/element-viewer-array": "0.0.19"
+    "@damienmortini/element-viewer-array": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/element/starter-gl/package.json
+++ b/packages/element/starter-gl/package.json
@@ -14,8 +14,8 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/core": "0.2.163",
-    "@damienmortini/damdom-ticker": "0.0.51"
+    "@damienmortini/core": "workspace:*",
+    "@damienmortini/damdom-ticker": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/element/starter-three/package.json
+++ b/packages/element/starter-three/package.json
@@ -14,9 +14,9 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/core": "0.2.163",
-    "@damienmortini/damdom-ticker": "0.0.51",
-    "@damienmortini/three": "0.1.204",
+    "@damienmortini/core": "workspace:*",
+    "@damienmortini/damdom-ticker": "workspace:*",
+    "@damienmortini/three": "workspace:*",
     "three": "0.184.0"
   },
   "publishConfig": {

--- a/packages/gltf/package.json
+++ b/packages/gltf/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@damienmortini/math": "0.0.28"
+    "@damienmortini/math": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -18,7 +18,7 @@
     "server": "node bin/index.js server"
   },
   "dependencies": {
-    "@damienmortini/server": "^1.0.90",
+    "@damienmortini/server": "workspace:^",
     "ws": "^8.21.0"
   },
   "publishConfig": {

--- a/packages/orbit-transform/package.json
+++ b/packages/orbit-transform/package.json
@@ -20,8 +20,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@damienmortini/gesture-observer": "0.0.10",
-    "@damienmortini/math": "0.0.28"
+    "@damienmortini/gesture-observer": "workspace:*",
+    "@damienmortini/math": "workspace:*"
   },
   "devDependencies": {
     "typescript": "6.0.3"

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -25,7 +25,7 @@
     "generateTypes": "npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir types"
   },
   "dependencies": {
-    "@damienmortini/core": "0.2.163",
+    "@damienmortini/core": "workspace:*",
     "fs-extra": "^11.3.5",
     "three": "0.184.0"
   },

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -16,7 +16,7 @@
     "generateTypes": "npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly"
   },
   "dependencies": {
-    "@damienmortini/signal": "0.0.14"
+    "@damienmortini/signal": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/trackball-transform/package.json
+++ b/packages/trackball-transform/package.json
@@ -21,8 +21,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@damienmortini/gesture-observer": "0.0.10",
-    "@damienmortini/math": "0.0.28"
+    "@damienmortini/gesture-observer": "workspace:*",
+    "@damienmortini/math": "workspace:*"
   },
   "devDependencies": {
     "typescript": "6.0.3"

--- a/packages/webgl/package.json
+++ b/packages/webgl/package.json
@@ -20,7 +20,7 @@
     "generateTypes": "npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir types"
   },
   "dependencies": {
-    "@damienmortini/math": "0.0.28"
+    "@damienmortini/math": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@damienmortini/eslint-config':
-        specifier: 0.0.32
+        specifier: workspace:*
         version: link:packages/eslint-config
       '@damienmortini/server':
         specifier: workspace:^
@@ -55,7 +55,7 @@ importers:
   packages/animation:
     dependencies:
       '@damienmortini/ticker':
-        specifier: 0.0.18
+        specifier: workspace:*
         version: link:../ticker
     devDependencies:
       typescript:
@@ -71,10 +71,10 @@ importers:
   packages/core:
     dependencies:
       '@damienmortini/gesture-observer':
-        specifier: 0.0.10
+        specifier: workspace:*
         version: link:../gesture-observer
       '@damienmortini/math':
-        specifier: 0.0.28
+        specifier: workspace:*
         version: link:../math
 
   packages/damdom/damdom-checkbox: {}
@@ -82,7 +82,7 @@ importers:
   packages/damdom/damdom-colorpicker:
     dependencies:
       '@damienmortini/math':
-        specifier: 0.0.28
+        specifier: workspace:*
         version: link:../../math
 
   packages/damdom/damdom-connector: {}
@@ -94,7 +94,7 @@ importers:
   packages/damdom/damdom-glslcanvas:
     dependencies:
       '@damienmortini/webgl':
-        specifier: 0.0.42
+        specifier: workspace:*
         version: link:../../webgl
 
   packages/damdom/damdom-gltfoptimizer:
@@ -112,19 +112,19 @@ importers:
   packages/damdom/damdom-gui:
     dependencies:
       '@damienmortini/damdom-checkbox':
-        specifier: 0.0.7
+        specifier: workspace:*
         version: link:../damdom-checkbox
       '@damienmortini/damdom-colorpicker':
-        specifier: 0.0.42
+        specifier: workspace:*
         version: link:../damdom-colorpicker
       '@damienmortini/damdom-select':
-        specifier: 0.0.7
+        specifier: workspace:*
         version: link:../damdom-select
       '@damienmortini/damdom-slider':
-        specifier: 0.0.7
+        specifier: workspace:*
         version: link:../damdom-slider
       '@damienmortini/damdom-textfield':
-        specifier: 0.0.7
+        specifier: workspace:*
         version: link:../damdom-textfield
 
   packages/damdom/damdom-linkableconnector: {}
@@ -148,13 +148,13 @@ importers:
   packages/damdom/damdom-ticker:
     dependencies:
       '@damienmortini/ticker':
-        specifier: 0.0.18
+        specifier: workspace:*
         version: link:../../ticker
 
   packages/damdom/damdom-viewport:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../../core
 
   packages/demo/demo-connector: {}
@@ -170,16 +170,16 @@ importers:
   packages/demo/demo-webgl:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../../core
       '@damienmortini/damdom-ticker':
-        specifier: 0.0.51
+        specifier: workspace:*
         version: link:../../damdom/damdom-ticker
       '@damienmortini/math':
-        specifier: 0.0.28
+        specifier: workspace:*
         version: link:../../math
       '@damienmortini/webgl':
-        specifier: 0.0.42
+        specifier: workspace:*
         version: link:../../webgl
 
   packages/dependency-cleaner:
@@ -191,16 +191,16 @@ importers:
   packages/element/animation-sprite:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../../core
       '@damienmortini/damdom-ticker':
-        specifier: 0.0.51
+        specifier: workspace:*
         version: link:../../damdom/damdom-ticker
 
   packages/element/animation-view:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../../core
 
   packages/element/input-colorpicker:
@@ -212,17 +212,17 @@ importers:
   packages/element/input-joystick:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../../core
 
   packages/element/input-knob:
     dependencies:
       '@damienmortini/math':
-        specifier: ^0.0.28
+        specifier: workspace:^
         version: link:../../math
     devDependencies:
       '@damienmortini/test-support':
-        specifier: 0.0.1
+        specifier: workspace:*
         version: link:../../test-support
       jsdom:
         specifier: ^29.1.1
@@ -231,7 +231,7 @@ importers:
   packages/element/input-number:
     devDependencies:
       '@damienmortini/test-support':
-        specifier: 0.0.1
+        specifier: workspace:*
         version: link:../../test-support
       jsdom:
         specifier: ^29.1.1
@@ -240,11 +240,11 @@ importers:
   packages/element/input-ruler:
     dependencies:
       '@damienmortini/ticker':
-        specifier: ^0.0.18
+        specifier: workspace:^
         version: link:../../ticker
     devDependencies:
       '@damienmortini/test-support':
-        specifier: 0.0.1
+        specifier: workspace:*
         version: link:../../test-support
       jsdom:
         specifier: ^29.1.1
@@ -253,7 +253,7 @@ importers:
   packages/element/input-signal-array:
     dependencies:
       '@damienmortini/element-viewer-array':
-        specifier: 0.0.19
+        specifier: workspace:*
         version: link:../viewer-array
 
   packages/element/input-signal-beat: {}
@@ -273,22 +273,22 @@ importers:
   packages/element/starter-gl:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../../core
       '@damienmortini/damdom-ticker':
-        specifier: 0.0.51
+        specifier: workspace:*
         version: link:../../damdom/damdom-ticker
 
   packages/element/starter-three:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../../core
       '@damienmortini/damdom-ticker':
-        specifier: 0.0.51
+        specifier: workspace:*
         version: link:../../damdom/damdom-ticker
       '@damienmortini/three':
-        specifier: 0.1.204
+        specifier: workspace:*
         version: link:../../three
       three:
         specifier: 0.184.0
@@ -350,7 +350,7 @@ importers:
   packages/gltf:
     dependencies:
       '@damienmortini/math':
-        specifier: 0.0.28
+        specifier: workspace:*
         version: link:../math
 
   packages/gltf-optimizer:
@@ -362,7 +362,7 @@ importers:
   packages/graph:
     dependencies:
       '@damienmortini/server':
-        specifier: ^1.0.90
+        specifier: workspace:^
         version: link:../server
       ws:
         specifier: ^8.21.0
@@ -381,10 +381,10 @@ importers:
   packages/orbit-transform:
     dependencies:
       '@damienmortini/gesture-observer':
-        specifier: 0.0.10
+        specifier: workspace:*
         version: link:../gesture-observer
       '@damienmortini/math':
-        specifier: 0.0.28
+        specifier: workspace:*
         version: link:../math
     devDependencies:
       typescript:
@@ -458,7 +458,7 @@ importers:
   packages/three:
     dependencies:
       '@damienmortini/core':
-        specifier: 0.2.163
+        specifier: workspace:*
         version: link:../core
       fs-extra:
         specifier: ^11.3.5
@@ -470,16 +470,16 @@ importers:
   packages/ticker:
     dependencies:
       '@damienmortini/signal':
-        specifier: 0.0.14
+        specifier: workspace:*
         version: link:../signal
 
   packages/trackball-transform:
     dependencies:
       '@damienmortini/gesture-observer':
-        specifier: 0.0.10
+        specifier: workspace:*
         version: link:../gesture-observer
       '@damienmortini/math':
-        specifier: 0.0.28
+        specifier: workspace:*
         version: link:../math
     devDependencies:
       typescript:
@@ -504,7 +504,7 @@ importers:
   packages/webgl:
     dependencies:
       '@damienmortini/math':
-        specifier: 0.0.28
+        specifier: workspace:*
         version: link:../math
 
   packages/worktree-setup: {}


### PR DESCRIPTION
## Summary

- require internal dependencies to resolve from the local workspace across version bumps
- preserve each package's existing published exact or caret dependency range

## Verification

- pnpm install --frozen-lockfile --lockfile-only
- pnpm run test
- packed all 24 affected publishable packages and verified all 40 published dependency ranges remain unchanged