### PR TITLE
Put lib on TypeScript 7 with a side-by-side compiler install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Two compilers are installed side by side, which is why no `package.json` here na
 `typescript` at a plain version:
 
 ```json
-"@typescript/native": "npm:typescript@^7.0.2",
-"typescript": "npm:@typescript/typescript6@^6.0.2"
+"@typescript/native": "npm:typescript@7.0.2",
+"typescript": "npm:@typescript/typescript6@6.0.2"
 ```
 
 `@typescript/native` is TypeScript 7 and owns the `tsc` that every `build` script and
@@ -46,6 +46,8 @@ fails before linting a line. The shim's binary is `tsc6`, so the two never colli
 
 `syncpack` reads both aliases and reconciles the semver inside them, but `syncpack update`
 skips aliased specifiers — `pnpm run upgrade` will never bump either one; move them by hand.
+Both are pinned exactly for that reason: a range no tool here reviews is one an install could
+drift silently.
 
 Delete both aliases and go back to a plain `typescript` at TypeScript 7.1, when the real
 compiler API lands.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,25 @@ others link *to*. `packageDirectories: ["packages"]` is where its own workspace 
 and `requiredPackages` names the two configs every gate resolves through
 (`@damienmortini/eslint-config` and `@damienmortini/typescript-config`), so a worktree that
 cannot resolve them fails setup instead of failing `lint` later with a foreign error.
+
+## TypeScript
+
+Two compilers are installed side by side, which is why no `package.json` here names
+`typescript` at a plain version:
+
+```json
+"@typescript/native": "npm:typescript@^7.0.2",
+"typescript": "npm:@typescript/typescript6@^6.0.2"
+```
+
+`@typescript/native` is TypeScript 7 and owns the `tsc` that every `build` script and
+`pnpm run typecheck` runs. The package *named* `typescript` is the TypeScript 6 compatibility
+shim, kept only so that anything importing the compiler API has an API to import — TypeScript 7
+ships none until 7.1, and without the shim `typescript-eslint` refuses to load and `eslint`
+fails before linting a line. The shim's binary is `tsc6`, so the two never collide.
+
+`syncpack` reads both aliases and reconciles the semver inside them, but `syncpack update`
+skips aliased specifiers — `pnpm run upgrade` will never bump either one; move them by hand.
+
+Delete both aliases and go back to a plain `typescript` at TypeScript 7.1, when the real
+compiler API lands.

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "@damienmortini/server": "workspace:^",
     "@damienmortini/typescript-config": "workspace:^",
     "@damienmortini/worktree-setup": "workspace:*",
-    "@typescript/native": "npm:typescript@^7.0.2",
+    "@typescript/native": "npm:typescript@7.0.2",
     "eslint": "10.5.0",
     "fast-glob": "^3.3.3",
     "jsdoc": "^4.0.5",
     "lerna": "^9.0.7",
     "sort-package-json": "4.0.0",
     "syncpack": "15.3.1",
-    "typescript": "npm:@typescript/typescript6@^6.0.2"
+    "typescript": "npm:@typescript/typescript6@6.0.2"
   },
   "worktreeSetup": {
     "packageDirectories": [

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
     "@damienmortini/server": "workspace:^",
     "@damienmortini/typescript-config": "workspace:^",
     "@damienmortini/worktree-setup": "workspace:*",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "eslint": "10.5.0",
     "fast-glob": "^3.3.3",
     "jsdoc": "^4.0.5",
     "lerna": "^9.0.7",
     "sort-package-json": "4.0.0",
     "syncpack": "15.3.1",
-    "typescript": "6.0.3"
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "worktreeSetup": {
     "packageDirectories": [

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -23,7 +23,7 @@
     "@damienmortini/ticker": "workspace:*"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -23,7 +23,7 @@
     "@damienmortini/ticker": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -23,7 +23,7 @@
     "eslint": "10.5.0",
     "eslint-plugin-simple-import-sort": "13.0.0",
     "globals": "^17.6.0",
-    "typescript": "6.0.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.64.0"
   },
   "publishConfig": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -23,7 +23,7 @@
     "eslint": "10.5.0",
     "eslint-plugin-simple-import-sort": "13.0.0",
     "globals": "^17.6.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript": "npm:@typescript/typescript6@6.0.2",
     "typescript-eslint": "^8.64.0"
   },
   "publishConfig": {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -31,7 +31,7 @@
     "jsdoc-to-markdown": "^9.1.3"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -31,7 +31,7 @@
     "jsdoc-to-markdown": "^9.1.3"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/generator/src/generators/typescript-package/index.ts
+++ b/packages/generator/src/generators/typescript-package/index.ts
@@ -34,7 +34,7 @@ export default async function ({ name, scope, path }) {
             build: 'tsc',
           },
           devDependencies: {
-            typescript: devDependencies.typescript,
+            '@typescript/native': devDependencies['@typescript/native'],
           },
         },
         null,

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -27,7 +27,7 @@
     "gl-matrix": "^3.4.4"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -27,7 +27,7 @@
     "gl-matrix": "^3.4.4"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/orbit-transform/package.json
+++ b/packages/orbit-transform/package.json
@@ -24,7 +24,7 @@
     "@damienmortini/math": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/orbit-transform/package.json
+++ b/packages/orbit-transform/package.json
@@ -24,7 +24,7 @@
     "@damienmortini/math": "workspace:*"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/package-builder/package.json
+++ b/packages/package-builder/package.json
@@ -23,7 +23,10 @@
     "chokidar": "^5.0.0",
     "esbuild": "0.28.1",
     "fast-glob": "^3.3.3",
-    "typescript": "6.0.3"
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  },
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/package-builder/package.json
+++ b/packages/package-builder/package.json
@@ -23,10 +23,10 @@
     "chokidar": "^5.0.0",
     "esbuild": "0.28.1",
     "fast-glob": "^3.3.3",
-    "typescript": "npm:@typescript/typescript6@^6.0.2"
+    "typescript": "npm:@typescript/typescript6@6.0.2"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/package-builder/src/index.ts
+++ b/packages/package-builder/src/index.ts
@@ -267,7 +267,10 @@ export const build = async ({
                       build.onEnd(async () => {
                         const { fileURLToPath } = await import('url');
                         const { spawn } = await import('child_process');
-                        const tscPath = fileURLToPath(import.meta.resolve('typescript/bin/tsc'));
+                        // `tsc6` rather than `tsc`: the package named `typescript` is the TypeScript 6
+                        // compatibility shim, which names its binary `tsc6` so it cannot collide with
+                        // TypeScript 7's. See the TypeScript section of CONTRIBUTING.md.
+                        const tscPath = fileURLToPath(import.meta.resolve('typescript/bin/tsc6'));
                         // Compile via the package tsconfig (-p) so module/resolution settings are honoured
                         // and --incremental stays valid. Await it and surface failures so missing or broken
                         // declarations fail the build instead of being silently dropped.

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -20,7 +20,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -20,7 +20,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/mime-types": "^3.0.1",
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/mime-types": "^3.0.1",
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -20,7 +20,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -20,7 +20,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/trackball-transform/package.json
+++ b/packages/trackball-transform/package.json
@@ -25,7 +25,7 @@
     "@damienmortini/math": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/trackball-transform/package.json
+++ b/packages/trackball-transform/package.json
@@ -25,7 +25,7 @@
     "@damienmortini/math": "workspace:*"
   },
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2"
+    "@typescript/native": "npm:typescript@7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@damienmortini/worktree-setup':
         specifier: workspace:*
         version: link:packages/worktree-setup
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
       eslint:
         specifier: 10.5.0
         version: 10.5.0(supports-color@7.2.0)
@@ -49,8 +52,8 @@ importers:
         specifier: 15.3.1
         version: 15.3.1
       typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
 
   packages/animation:
     dependencies:
@@ -58,9 +61,9 @@ importers:
         specifier: workspace:*
         version: link:../ticker
     devDependencies:
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/blend2gltf:
     dependencies:
@@ -314,11 +317,11 @@ importers:
         specifier: ^17.6.0
         version: 17.7.0
       typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-eslint:
         specifier: ^8.64.0
-        version: 8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
 
   packages/generator:
     dependencies:
@@ -329,9 +332,9 @@ importers:
         specifier: ^9.1.3
         version: 9.1.3
     devDependencies:
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/gesture-observer: {}
 
@@ -374,9 +377,9 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4
     devDependencies:
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/orbit-transform:
     dependencies:
@@ -387,9 +390,9 @@ importers:
         specifier: workspace:*
         version: link:../math
     devDependencies:
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/package-builder:
     dependencies:
@@ -403,14 +406,18 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+    devDependencies:
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/router:
     devDependencies:
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/server:
     dependencies:
@@ -439,15 +446,15 @@ importers:
       '@types/mime-types':
         specifier: ^3.0.1
         version: 3.0.1
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/signal:
     devDependencies:
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/test-support:
     dependencies:
@@ -482,9 +489,9 @@ importers:
         specifier: workspace:*
         version: link:../math
     devDependencies:
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
   packages/typescript-config:
     dependencies:
@@ -1430,6 +1437,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.64.0':
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@vue/compiler-core@3.5.38':
     resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
@@ -3787,6 +3918,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   typical@7.3.0:
     resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
     engines: {node: '>=12.17'}
@@ -4878,40 +5014,40 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@typescript-eslint/visitor-keys': 8.64.0
       eslint: 10.5.0(supports-color@7.2.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3(supports-color@7.2.0)
       eslint: 10.5.0(supports-color@7.2.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.64.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.64.0
       debug: 4.4.3(supports-color@7.2.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -4920,19 +5056,19 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.64.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
       debug: 4.4.3(supports-color@7.2.0)
       eslint: 10.5.0(supports-color@7.2.0)
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -4940,29 +5076,29 @@ snapshots:
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.64.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.64.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)
       eslint: 10.5.0(supports-color@7.2.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -4970,6 +5106,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@vue/compiler-core@3.5.38':
     dependencies:
@@ -7515,9 +7715,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -7553,20 +7753,43 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  typescript-eslint@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.5.0(supports-color@7.2.0))(supports-color@7.2.0)
       eslint: 10.5.0(supports-color@7.2.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   typical@7.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         specifier: workspace:*
         version: link:packages/worktree-setup
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
       eslint:
         specifier: 10.5.0
@@ -52,7 +52,7 @@ importers:
         specifier: 15.3.1
         version: 15.3.1
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: npm:@typescript/typescript6@6.0.2
         version: '@typescript/typescript6@6.0.2'
 
   packages/animation:
@@ -62,7 +62,7 @@ importers:
         version: link:../ticker
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/blend2gltf:
@@ -317,7 +317,7 @@ importers:
         specifier: ^17.6.0
         version: 17.7.0
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: npm:@typescript/typescript6@6.0.2
         version: '@typescript/typescript6@6.0.2'
       typescript-eslint:
         specifier: ^8.64.0
@@ -333,7 +333,7 @@ importers:
         version: 9.1.3
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/gesture-observer: {}
@@ -378,7 +378,7 @@ importers:
         version: 3.4.4
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/orbit-transform:
@@ -391,7 +391,7 @@ importers:
         version: link:../math
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/package-builder:
@@ -406,17 +406,17 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: npm:@typescript/typescript6@6.0.2
         version: '@typescript/typescript6@6.0.2'
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/router:
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/server:
@@ -447,13 +447,13 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/signal:
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/test-support:
@@ -490,7 +490,7 @@ importers:
         version: link:../math
     devDependencies:
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
 
   packages/typescript-config:


### PR DESCRIPTION
TypeScript 7.0.2 is out, and this repository was held at 6.0.3 by one thing: `typescript-eslint` throws `typescript-eslint does not support TS 7.0` at load. That is not a typescript-eslint bug — **TypeScript 7 ships no programmatic compiler API at all** until 7.1 ([typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940), no timeline).

So install both compilers, the way Microsoft documents it:

```json
"@typescript/native": "npm:typescript@7.0.2",
"typescript": "npm:@typescript/typescript6@6.0.2"
```

`@typescript/native` is TypeScript 7 and owns `tsc`. The package *named* `typescript` is the TypeScript 6 compatibility shim, so anything reaching for the compiler API gets an API to reach for. The shim's binary is `tsc6`, so the two never collide.

Rather than putting both keys in all 11 files, each package declares what it actually uses:

| Package | Declares | Because |
| --- | --- | --- |
| root | both | runs `tsc` for `typecheck`, needs the shim resolvable |
| the 9 with `build: tsc` | `@typescript/native` | they only need a compiler binary |
| `eslint-config` | shim | `typescript-eslint` needs the compiler API |
| `package-builder` | both | builds with `tsc`, resolves the API at runtime |

### One real bug this surfaced

`package-builder` emits declarations by spawning `import.meta.resolve('typescript/bin/tsc')`. The shim ships **only** `bin/tsc6` — `bin/tsc` does not exist, so that resolves to a nonexistent file and declaration emit would crash at runtime. Fixed by pointing it at `tsc6` (it emitted with TypeScript 6 before this PR too, so no behaviour change).

`pnpm run build` and `npm test` both stay green with this broken, because nothing in this repository consumes `package-builder`. Verified by hand against a fixture package outside the repo — correct `.d.ts` and `.d.ts.map` emitted. Filed as a coverage gap.

TypeScript 7 exports no `bin` subpath at all (`ERR_PACKAGE_PATH_NOT_EXPORTED`), so `package-builder` cannot move to 7 here yet.

### syncpack — the open question in the todo

`pnpm run upgrade` runs `syncpack update && syncpack fix`. Tested on this repository:

- `syncpack lint` / `fix` — read both aliases, understand the semver *inside* them, and reconcile mismatches while preserving the `npm:` prefix. Verified by deliberately skewing one spec to `^6.0.1` and watching `fix` restore it.
- `syncpack update` — **skips** aliased specifiers. It listed 16 other packages to bump and named neither alias.

So the aliases survive `pnpm run upgrade` intact — `fix` keeps the copies in step, and it reads inside the alias. The cost is that neither will ever be auto-*bumped*. Both are therefore pinned exactly rather than with a caret (review feedback): a range no tool here reviews is one an install could drift inside silently. `CONTRIBUTING.md` records both facts.

### Verification

`tsc` 7.0.2 · `tsc6` 6.0.3 · `import('typescript').version` 6.0.3 — matching the todo's scratch-project measurements.

`pnpm run build` ✅ · `eslint packages` ✅ (the point of the PR) · `pnpm run typecheck` ✅ · `pnpm -r run test` ✅ · `syncpack lint` ✅

### Scope notes

Landed separately from #70 rather than folded in — #70 is a clean dependency bump already reviewed as one, and its title is literally "except TypeScript". The lockfile here carries only the alias; no unrelated bumps rode along.

Both aliases come back out at TypeScript 7.1, when the real compiler API lands. `CONTRIBUTING.md` says so at the only place someone would look.
