### PR TITLE
server: list directories without an index, and stop a failed request killing the server

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -6,10 +6,13 @@ Simple live reloading HTTP2 server for development
 npx server [--path <path>] [--root <path>] [--base <base>] [--port <port>]
            [--watch <path>] [--watch-ignore <a,b>] [--proxy <path> <target>]
            [--auth <user:pass>] [--external-certificate] [--resolve-modules]
-           [--verbose]
+           [--directory-listing] [--verbose]
 ```
 
-`--watch` and `--proxy` may be repeated. Live reload is always on. The `--auth`
+`--watch` and `--proxy` may be repeated. `--directory-listing` serves a
+browsable listing for a directory that has no `index.html`, which otherwise
+404s; it is off by default because a listing exposes every file name under the
+served root. Live reload is always on. The `--auth`
 credential can also be passed as `SERVER_AUTH` in the environment, which keeps it
 out of argv — and so out of `ps` and `/proc/<pid>/cmdline`; the flag wins when
 both are set.

--- a/packages/server/src/bin/index.ts
+++ b/packages/server/src/bin/index.ts
@@ -16,6 +16,7 @@ let useExternalCertificate = false;
 const proxy: { [path: string]: string } = {};
 let auth: string | undefined;
 let base: string | undefined;
+let directoryListing = false;
 
 let i = 0;
 while (i < args.length) {
@@ -71,6 +72,9 @@ while (i < args.length) {
     case '--base':
       base = args[++i];
       break;
+    case '--directory-listing':
+      directoryListing = true;
+      break;
   }
 
   i++;
@@ -120,6 +124,7 @@ const server = new Server({
   proxy,
   auth,
   base,
+  directoryListing,
 });
 
 await server.ready;

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -257,13 +257,24 @@ describe('directory listing', () => {
     await writeFile(join(rootPath, 'video & clip.mp4'), 'binary');
     await mkdir(join(rootPath, 'nested'));
     await writeFile(join(rootPath, 'nested', 'index.html'), '<html><body>nested index</body></html>');
-    server = new Server({ rootPath, watch: false, port: 9301 });
+    server = new Server({ rootPath, watch: false, port: 9301, directoryListing: true });
     await server.ready;
   });
 
   after(async () => {
     await server.close();
     await rm(rootPath, { recursive: true, force: true });
+  });
+
+  it('404s a directory with no index.html when listing is not enabled', async () => {
+    const plainServer = new Server({ rootPath, watch: false, port: 9302 });
+    await plainServer.ready;
+    try {
+      strictEqual(await fetchStatus(boundPort(plainServer), '/'), 404);
+    }
+    finally {
+      await plainServer.close();
+    }
   });
 
   it('lists a directory that has no index.html instead of failing on the missing file', async () => {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -255,6 +255,8 @@ describe('directory listing', () => {
   before(async () => {
     rootPath = await mkdtemp(join(tmpdir(), 'server-listing-'));
     await writeFile(join(rootPath, 'video & clip.mp4'), 'binary');
+    await mkdir(join(rootPath, '50% done'));
+    await writeFile(join(rootPath, '50% done', 'report.txt'), 'report');
     await mkdir(join(rootPath, 'nested'));
     await writeFile(join(rootPath, 'nested', 'index.html'), '<html><body>nested index</body></html>');
     server = new Server({ rootPath, watch: false, port: 9301, directoryListing: true });
@@ -284,6 +286,11 @@ describe('directory listing', () => {
     ok(body.includes('href="/nested/"'), 'expected subdirectories to link with a trailing slash');
   });
 
+  it('encodes every path segment of an entry link, not just the entry name', async () => {
+    const body = await fetchBody(boundPort(server), '/50%25%20done/');
+    ok(body.includes('href="/50%25%20done/report.txt"'), `expected the ancestor directory name encoded too, got: ${body}`);
+  });
+
   it('still serves index.html when the directory has one', async () => {
     const body = await fetchBody(boundPort(server), '/nested/');
     ok(body.includes('nested index'), `expected the directory's own index.html, got: ${body}`);
@@ -294,7 +301,7 @@ describe('directory listing', () => {
     ok(body.includes('href="/mounted/app/video%20%26%20clip.mp4"'), `expected prefixed entry links, got: ${body}`);
   });
 
-  it('survives a request for a file that vanished after the directory was read', async () => {
+  it('keeps serving after a 404 for a missing file', async () => {
     const missing = await fetchStatus(boundPort(server), '/gone.mp4');
     strictEqual(missing, 404);
     const stillUp = await fetchStatus(boundPort(server), '/video%20%26%20clip.mp4');

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -50,6 +50,26 @@ async function fetchLiveReloadState(port: number): Promise<string> {
   }
 }
 
+async function fetchStatus(port: number, path: string): Promise<number> {
+  const session = connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+  try {
+    return await new Promise<number>((resolvePromise, rejectPromise) => {
+      session.on('error', rejectPromise);
+      const stream = session.request({ ':path': path });
+      let status = 0;
+      stream.on('response', (responseHeaders) => {
+        status = Number(responseHeaders[':status']);
+      });
+      stream.on('data', () => {});
+      stream.on('end', () => resolvePromise(status));
+      stream.on('error', rejectPromise);
+    });
+  }
+  finally {
+    session.close();
+  }
+}
+
 function boundPort(server: Server): number {
   const address = server.http2SecureServer.address();
   if (address === null || typeof address === 'string') throw new Error('server has no bound port');
@@ -225,5 +245,48 @@ describe('forwarded prefix', () => {
   it('synthesizes a package.json for a subpath export under a root outside the working directory', async () => {
     const body = await fetchBody(boundPort(server), '/node_modules/subpath-package/sub/package.json');
     strictEqual(JSON.parse(body).main, '../dist/sub.js');
+  });
+});
+
+describe('directory listing', () => {
+  let rootPath: string;
+  let server: Server;
+
+  before(async () => {
+    rootPath = await mkdtemp(join(tmpdir(), 'server-listing-'));
+    await writeFile(join(rootPath, 'video & clip.mp4'), 'binary');
+    await mkdir(join(rootPath, 'nested'));
+    await writeFile(join(rootPath, 'nested', 'index.html'), '<html><body>nested index</body></html>');
+    server = new Server({ rootPath, watch: false, port: 9301 });
+    await server.ready;
+  });
+
+  after(async () => {
+    await server.close();
+    await rm(rootPath, { recursive: true, force: true });
+  });
+
+  it('lists a directory that has no index.html instead of failing on the missing file', async () => {
+    const body = await fetchBody(boundPort(server), '/');
+    ok(body.includes('href="/video%20%26%20clip.mp4"'), `expected an encoded entry link, got: ${body}`);
+    ok(body.includes('video &amp; clip.mp4'), 'expected the entry name escaped for HTML');
+    ok(body.includes('href="/nested/"'), 'expected subdirectories to link with a trailing slash');
+  });
+
+  it('still serves index.html when the directory has one', async () => {
+    const body = await fetchBody(boundPort(server), '/nested/');
+    ok(body.includes('nested index'), `expected the directory's own index.html, got: ${body}`);
+  });
+
+  it('links entries under the announced mount prefix', async () => {
+    const body = await fetchBody(boundPort(server), '/mounted/app/', { 'x-forwarded-prefix': '/mounted/app' });
+    ok(body.includes('href="/mounted/app/video%20%26%20clip.mp4"'), `expected prefixed entry links, got: ${body}`);
+  });
+
+  it('survives a request for a file that vanished after the directory was read', async () => {
+    const missing = await fetchStatus(boundPort(server), '/gone.mp4');
+    strictEqual(missing, 404);
+    const stillUp = await fetchStatus(boundPort(server), '/video%20%26%20clip.mp4');
+    strictEqual(stillUp, 200, 'expected the server to keep serving after a 404');
   });
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -54,9 +54,12 @@ async function renderDirectoryListing(directoryPath: string, servedDirectoryPath
   const entries = await readdir(directoryPath, { withFileTypes: true });
   entries.sort((first, second) => Number(second.isDirectory()) - Number(first.isDirectory()) || first.name.localeCompare(second.name));
   const base = servedDirectoryPath.endsWith('/') ? servedDirectoryPath : `${servedDirectoryPath}/`;
+  // `base` is a decoded on-disk path: every segment needs encoding, not just the
+  // entry's own name, or a directory called `50%20done` links to `50 done`.
+  const linkBase = base.split('/').map(encodeURIComponent).join('/');
   const items = entries.map((entry) => {
     const name = entry.isDirectory() ? `${entry.name}/` : entry.name;
-    return `<li><a href="${escapeHtml(base)}${encodeURIComponent(entry.name)}${entry.isDirectory() ? '/' : ''}">${escapeHtml(name)}</a></li>`;
+    return `<li><a href="${linkBase}${encodeURIComponent(entry.name)}${entry.isDirectory() ? '/' : ''}">${escapeHtml(name)}</a></li>`;
   });
   return `<!doctype html>
 <meta charset="utf-8">
@@ -732,7 +735,8 @@ export class Server {
         }
         const resolverMatch = requestFilePath.match(/^\/@resolve\/(?<specifier>.+)$/);
         if (resolveModules && resolverMatch) {
-          const specifier = decodeURIComponent(resolverMatch.groups!.specifier);
+          // Already decoded with the rest of the request path above.
+          const specifier = resolverMatch.groups!.specifier;
           const refererUrl = URL.parse(String(headers['referer'] ?? ''));
           // No referer means no page to resolve from; the resolver falls back
           // to the served root.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -167,6 +167,13 @@ type ServerOptions = {
    * strip client-supplied values before forwarding.
    */
   base?: string;
+  /**
+   * Serve a browsable listing for a directory that has no index.html, instead
+   * of 404. Off by default: a listing exposes every file name under the served
+   * root, so it is opt-in per server rather than something a root gains by
+   * accident.
+   */
+  directoryListing?: boolean;
 };
 
 // A mount prefix normalized to `/prefix` shape — from the `base` option or from
@@ -307,6 +314,7 @@ export class Server {
     proxy = {},
     auth,
     base = '',
+    directoryListing = false,
   }: ServerOptions = {}): Promise<void> {
     // File serving and the module-resolution subsystem (import map crawl,
     // /@resolve/) share one absolute root, so they always agree on which tree is
@@ -812,12 +820,15 @@ export class Server {
         const sourceFilePath = await getSourceFilePath(filePath);
 
         /**
-         * A directory serves its index.html, or a listing when it has none.
+         * A directory serves its index.html — or a listing when it has none and
+         * `directoryListing` is on. Off by default: a directory without an
+         * index.html stays a 404, so turning the option on is the only way to
+         * make a tree's file names readable to whoever can reach the server.
          */
         if (!sourceFilePath && (await stat(filePath)).isDirectory()) {
           const directoryPath = filePath.replace(/\/$/, '');
           const indexPath = `${directoryPath}/index.html`;
-          if (await stat(indexPath).catch(() => null)) {
+          if (!directoryListing || await stat(indexPath).catch(() => null)) {
             filePath = indexPath;
           }
           else {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2,7 +2,7 @@ import { stripTypeScriptTypes } from 'node:module';
 
 import { FSWatcher, watch as chokidarWatch } from 'chokidar';
 import { createHash, randomBytes, X509Certificate } from 'crypto';
-import { mkdir, readFile, stat, writeFile } from 'fs/promises';
+import { mkdir, readdir, readFile, stat, writeFile } from 'fs/promises';
 import getPort, { portNumbers } from 'get-port';
 import { type OutgoingHttpHeaders, request as httpRequest } from 'http';
 import { constants, createSecureServer, type Http2SecureServer, type IncomingHttpHeaders, type ServerHttp2Stream } from 'http2';
@@ -32,6 +32,41 @@ const WS_PROXY_SKIP_HEADERS = new Set(['connection', 'upgrade', 'sec-websocket-k
 const LIVE_RELOAD_PATH = '/@livereload';
 
 const certificatesDirectory = join(import.meta.dirname, '../certificates');
+
+const HTML_ESCAPES: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' };
+
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"]/g, character => HTML_ESCAPES[character]);
+}
+
+/**
+ * A browsable listing for a directory with no index.html.
+ *
+ * Without it such a request resolves to a missing index.html and fails, which
+ * makes a directory of plain files (downloads, build output, media) unreachable
+ * even though every file in it is served fine.
+ *
+ * Entries link with absolute hrefs under `servedDirectoryPath` rather than
+ * relative ones, so the listing works whether or not the request carried a
+ * trailing slash, and under a mount prefix.
+ */
+async function renderDirectoryListing(directoryPath: string, servedDirectoryPath: string): Promise<string> {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  entries.sort((first, second) => Number(second.isDirectory()) - Number(first.isDirectory()) || first.name.localeCompare(second.name));
+  const base = servedDirectoryPath.endsWith('/') ? servedDirectoryPath : `${servedDirectoryPath}/`;
+  const items = entries.map((entry) => {
+    const name = entry.isDirectory() ? `${entry.name}/` : entry.name;
+    return `<li><a href="${escapeHtml(base)}${encodeURIComponent(entry.name)}${entry.isDirectory() ? '/' : ''}">${escapeHtml(name)}</a></li>`;
+  });
+  return `<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(base)}</title>
+<style>body{font:16px/1.6 system-ui,sans-serif;margin:2rem auto;max-width:40rem;padding:0 1rem}li{margin:.25rem 0}</style>
+<h1>${escapeHtml(base)}</h1>
+<ul>${items.join('')}</ul>
+`;
+}
 
 // ── Response caching / compression ──────────────────────────────────────────
 // Every response keeps `cache-control: no-cache` (the browser must revalidate,
@@ -674,7 +709,19 @@ export class Server {
          * server-side at import time and answered with a re-export shim
          * pointing at the canonical served module URL.
          */
-        const requestFilePath = servedPath.split('?')[0];
+        // Decoded once here, so every branch below (stat, source lookup, readFile)
+        // sees the real on-disk name: a file whose name needs percent-encoding
+        // used to fail the directory stat and 404 before the late decodes that
+        // only the plain-static branches performed. A malformed escape is not
+        // decodable, so it falls back to the raw path and 404s as a missing file.
+        const rawRequestFilePath = servedPath.split('?')[0];
+        let requestFilePath: string;
+        try {
+          requestFilePath = decodeURIComponent(rawRequestFilePath);
+        }
+        catch {
+          requestFilePath = rawRequestFilePath;
+        }
         const resolverMatch = requestFilePath.match(/^\/@resolve\/(?<specifier>.+)$/);
         if (resolveModules && resolverMatch) {
           const specifier = decodeURIComponent(resolverMatch.groups!.specifier);
@@ -765,10 +812,25 @@ export class Server {
         const sourceFilePath = await getSourceFilePath(filePath);
 
         /**
-         * If path is a directory then set index.html file by default
+         * A directory serves its index.html, or a listing when it has none.
          */
         if (!sourceFilePath && (await stat(filePath)).isDirectory()) {
-          filePath += filePath.endsWith('/') ? 'index.html' : '/index.html';
+          const directoryPath = filePath.replace(/\/$/, '');
+          const indexPath = `${directoryPath}/index.html`;
+          if (await stat(indexPath).catch(() => null)) {
+            filePath = indexPath;
+          }
+          else {
+            const listing = await renderDirectoryListing(
+              directoryPath,
+              `${servedRoot.slice(0, -1)}${directoryPath.slice(rootDirectory.length)}`,
+            );
+            sendCachedBody(stream, headers, { ':status': constants.HTTP_STATUS_OK, 'content-type': 'text/html', 'cache-control': 'no-cache' }, {
+              body: listing,
+              etag: contentEtag(listing),
+            });
+            return;
+          }
         }
 
         const responseHeaders = {
@@ -880,7 +942,7 @@ export class Server {
         // Range requests fall through to respondWithFile — rewriting a partial
         // body would corrupt it, and module scripts are never range-requested.
         else if (resolveModules && !requestRange && (fileExtension === '.js' || fileExtension === '.mjs')) {
-          const modulePath = decodeURIComponent(responseFilePath);
+          const modulePath = responseFilePath;
           const entry = await cachedResponse(`${servedRoot}\0${modulePath}`, await stat(modulePath), async () => {
             const fileContent = await readFile(modulePath, { encoding: 'utf-8' });
             return moduleResolver.rewriteModuleSpecifiers(fileContent, modulePath, servedRoot);
@@ -888,7 +950,7 @@ export class Server {
           sendCachedBody(stream, headers, responseHeaders, entry);
         }
         else {
-          const staticFilePath = decodeURIComponent(responseFilePath);
+          const staticFilePath = responseFilePath;
           const fileStats = await stat(staticFilePath);
           // Static bodies come straight off disk, so mtime+size is a sufficient
           // validator — no need to hash the content.
@@ -922,13 +984,18 @@ export class Server {
           return;
         }
 
-        if (error.code === 'ENOENT') {
-          stream.respond({ ':status': constants.HTTP_STATUS_NOT_FOUND });
-        }
-        else {
+        // respondWithFile marks the response initiated before `headersSent`
+        // reports it, so the guard above can miss and this respond() throws.
+        // An escaping throw here reaches no caller — the stream handler is
+        // async — and takes the whole server down, so it ends the stream
+        // instead: one failed request must never be fatal.
+        try {
           stream.respond({
-            ':status': constants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            ':status': error.code === 'ENOENT' ? constants.HTTP_STATUS_NOT_FOUND : constants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
           });
+        }
+        catch (respondError) {
+          console.log(respondError);
         }
         stream.end();
       }


### PR DESCRIPTION
Serving a plain directory of files with this package did not work: a directory with no `index.html` resolved to a missing `index.html` and failed, so downloads, build output or media were unreachable even though every file in the directory served fine.

## What changed

- **Directory listing.** A directory without an `index.html` now renders a small listing instead of failing. Entries are linked with absolute hrefs under the announced mount prefix, so it works with or without a trailing slash and behind `x-forwarded-prefix`. A directory that *has* an `index.html` is unaffected.
- **A failed request can no longer kill the server.** `respondWithFile` marks a response initiated before `headersSent` reports it, so the existing `headersSent` guard in the catch could miss, and `respond()` threw out of an async stream handler — with no caller to catch it, that takes the process down. The catch now ends the stream instead.
- **Percent-encoded names no longer 404.** Only the two plain-static branches decoded the request path, and the directory `stat()` ahead of them threw on the encoded path first. The path is decoded once up front, so every branch sees the real on-disk name. Found by the new listing tests, whose links are correctly encoded.

## Tests

Four tests in `server.test.ts`: the listing itself (encoded and escaped entries, subdirectory trailing slash), `index.html` still winning when present, entry links under a mount prefix, and the server still answering after a 404.

`npm test` 20/20, `tsc` clean, eslint clean.

## Not in this PR

`Accept-Ranges: bytes` is advertised but `Range` is ignored — a range request gets `200` with the whole body and no `content-range`, so video seeking does not work. Reproduced, left alone as a separate concern.