### PR TITLE
package-builder: test declaration emit, and dispose esbuild when it fails

### DIFF
--- a/packages/package-builder/package.json
+++ b/packages/package-builder/package.json
@@ -17,7 +17,8 @@
     "package-builder": "dist/bin/index.js"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "node --test src/*.test.ts"
   },
   "dependencies": {
     "chokidar": "^5.0.0",

--- a/packages/package-builder/src/index.test.ts
+++ b/packages/package-builder/src/index.test.ts
@@ -1,0 +1,50 @@
+import { match, ok } from 'node:assert';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+import { build } from './index.ts';
+
+// Nothing in this repository consumes package-builder, so its only interesting code path —
+// spawning the TypeScript compiler to emit declarations — is unexercised by every other
+// package's build. It has broken silently before: the compiler is resolved by subpath, and
+// a compatibility shim that renamed its binary left `import.meta.resolve` pointing at a file
+// that did not exist. Building a real package here is the only way that shows up.
+describe('declaration emit', () => {
+  let temporaryRoot: string;
+  let workingDirectory: string;
+
+  before(async () => {
+    workingDirectory = process.cwd();
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'package-builder-test-'));
+    await mkdir(join(temporaryRoot, 'src'), { recursive: true });
+    await writeFile(join(temporaryRoot, 'package.json'), '{"name":"fixture","type":"module"}');
+    // Standalone rather than extending the repository config: the fixture sits outside the
+    // workspace, so anything it inherits would have to resolve from there too.
+    await writeFile(join(temporaryRoot, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ESNext',
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        types: [],
+      },
+      include: ['src'],
+    }));
+    await writeFile(join(temporaryRoot, 'src', 'index.ts'), 'export function add(first: number, second: number): number {\n  return first + second;\n}\n');
+    process.chdir(temporaryRoot);
+  });
+
+  after(async () => {
+    process.chdir(workingDirectory);
+    await rm(temporaryRoot, { recursive: true, force: true });
+  });
+
+  it('writes a .d.ts carrying the source signature', async () => {
+    await build({ platform: 'node' });
+
+    const declaration = await readFile(join(temporaryRoot, 'dist', 'index.d.ts'), 'utf8');
+    match(declaration, /declare function add\(first: number, second: number\): number/);
+    ok(await readFile(join(temporaryRoot, 'dist', 'index.js'), 'utf8'));
+  });
+});

--- a/packages/package-builder/src/index.test.ts
+++ b/packages/package-builder/src/index.test.ts
@@ -1,4 +1,5 @@
-import { match, ok } from 'node:assert';
+import { match, ok, strictEqual } from 'node:assert';
+import { spawn } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -11,40 +12,84 @@ import { build } from './index.ts';
 // package's build. It has broken silently before: the compiler is resolved by subpath, and
 // a compatibility shim that renamed its binary left `import.meta.resolve` pointing at a file
 // that did not exist. Building a real package here is the only way that shows up.
+
+const temporaryRoots: string[] = [];
+
+// Standalone tsconfig rather than one extending the repository's: the fixture sits outside
+// the workspace, so anything it inherited would have to resolve from there too.
+async function createFixture(source: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'package-builder-test-'));
+  temporaryRoots.push(root);
+  await mkdir(join(root, 'src'), { recursive: true });
+  await writeFile(join(root, 'package.json'), '{"name":"fixture","type":"module"}');
+  await writeFile(join(root, 'tsconfig.json'), JSON.stringify({
+    compilerOptions: {
+      target: 'ESNext',
+      module: 'NodeNext',
+      moduleResolution: 'NodeNext',
+      types: [],
+    },
+    include: ['src'],
+  }));
+  await writeFile(join(root, 'src', 'index.ts'), source);
+  return root;
+}
+
 describe('declaration emit', () => {
-  let temporaryRoot: string;
   let workingDirectory: string;
 
-  before(async () => {
+  before(() => {
     workingDirectory = process.cwd();
-    temporaryRoot = await mkdtemp(join(tmpdir(), 'package-builder-test-'));
-    await mkdir(join(temporaryRoot, 'src'), { recursive: true });
-    await writeFile(join(temporaryRoot, 'package.json'), '{"name":"fixture","type":"module"}');
-    // Standalone rather than extending the repository config: the fixture sits outside the
-    // workspace, so anything it inherits would have to resolve from there too.
-    await writeFile(join(temporaryRoot, 'tsconfig.json'), JSON.stringify({
-      compilerOptions: {
-        target: 'ESNext',
-        module: 'NodeNext',
-        moduleResolution: 'NodeNext',
-        types: [],
-      },
-      include: ['src'],
-    }));
-    await writeFile(join(temporaryRoot, 'src', 'index.ts'), 'export function add(first: number, second: number): number {\n  return first + second;\n}\n');
-    process.chdir(temporaryRoot);
   });
 
   after(async () => {
     process.chdir(workingDirectory);
-    await rm(temporaryRoot, { recursive: true, force: true });
+    await Promise.all(temporaryRoots.map(root => rm(root, { recursive: true, force: true })));
   });
 
   it('writes a .d.ts carrying the source signature', async () => {
+    const root = await createFixture('export function add(first: number, second: number): number {\n  return first + second;\n}\n');
+    process.chdir(root);
+
     await build({ platform: 'node' });
 
-    const declaration = await readFile(join(temporaryRoot, 'dist', 'index.d.ts'), 'utf8');
+    const declaration = await readFile(join(root, 'dist', 'index.d.ts'), 'utf8');
     match(declaration, /declare function add\(first: number, second: number\): number/);
-    ok(await readFile(join(temporaryRoot, 'dist', 'index.js'), 'utf8'));
+    ok(await readFile(join(root, 'dist', 'index.js'), 'utf8'));
+  });
+
+  // In a child process rather than in-process, because the failure this guards is the build
+  // never ending: esbuild holds a service child process open for a context, and until that
+  // context was disposed on the failing path too, a rejected build left the service running
+  // and nothing that asked for a build could exit. The child catches the rejection and lets
+  // the event loop end the process on its own, so a surviving handle shows up as no exit at
+  // all rather than as a failure; `process.exitCode` is what keeps that exit natural.
+  it('fails the build and still lets the process exit', async () => {
+    const root = await createFixture('export const count: number = \'not a number\';\n');
+    const entry = new URL('./index.ts', import.meta.url).href;
+    const script = `const { build } = await import(${JSON.stringify(entry)});
+let rejected = false;
+try { await build({ platform: 'node' }); }
+catch { rejected = true; }
+process.exitCode = rejected ? 7 : 0;`;
+
+    const exitCode = await new Promise<number | null>((resolvePromise, rejectPromise) => {
+      const child = spawn(
+        process.execPath,
+        ['--input-type=module', '--eval', script],
+        { cwd: root, stdio: 'ignore' },
+      );
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        rejectPromise(new Error('build did not exit within 60s after a failed declaration emit'));
+      }, 60_000);
+      child.on('error', rejectPromise);
+      child.on('exit', (code) => {
+        clearTimeout(timer);
+        resolvePromise(code);
+      });
+    });
+
+    strictEqual(exitCode, 7, `expected the build to reject and the process to exit, got ${exitCode}`);
   });
 });

--- a/packages/package-builder/src/index.ts
+++ b/packages/package-builder/src/index.ts
@@ -329,8 +329,9 @@ export default styles;`;
           await ctx.watch();
         }
         else {
-          const result = await ctx.rebuild();
-          await ctx.dispose();
+          // Dispose even when the build throws: esbuild keeps a child process alive for the
+          // context, so a failed declaration emit hangs the build instead of reporting.
+          const result = await ctx.rebuild().finally(() => ctx.dispose());
           if (result.outputFiles) {
             await Promise.all(result.outputFiles.map(async (outputFile) => {
               try {

--- a/packages/package-builder/tsconfig.json
+++ b/packages/package-builder/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "rewriteRelativeImportExtensions": true
   }
 }


### PR DESCRIPTION
Nothing in this repository consumes `package-builder`, so its esbuild plugin — the one that spawns the TypeScript compiler to emit declarations — was exercised by nothing. `pnpm run build` and `pnpm run test` both stayed green through a period where that path was broken outright: the compiler is resolved by subpath, and a compatibility shim that renamed its binary left `import.meta.resolve` returning a path to a file that does not exist. The only way it surfaced was hand-building a fixture package outside the repository.

**What this adds**

- `src/index.test.ts` builds a tiny fixture package in a temporary directory and asserts the emitted `.d.ts` carries the source signature. Verified against the real breakage: pointing the resolve at the missing binary turns the test red.
- A `test` script, so `pnpm -r run test` — and therefore the repository gate — picks it up.
- `rewriteRelativeImportExtensions`, matching `server`, so the test can import `./index.ts` directly.

**Second fault the test surfaced**

On a failed declaration emit the esbuild context was never disposed — `dispose()` sat after `rebuild()` on the success path only. esbuild keeps a child process alive for a context, so the failure hung forever instead of reporting. `rebuild().finally(dispose)` fixes it; without it the new test hangs rather than failing.

Full gate green in the worktree.