### PR TITLE
Fix lerna resolving no packages, and publish to npm only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,3 @@ jobs:
       - run: pnpm exec lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - uses: actions/setup-node@v2
-        with:
-          registry-url: https://npm.pkg.github.com/
-      - run: pnpm exec lerna publish from-package --yes --no-verify-access
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/lerna.json
+++ b/lerna.json
@@ -1,3 +1,4 @@
 {
-  "version": "independent"
+  "version": "independent",
+  "npmClient": "pnpm"
 }


### PR DESCRIPTION
## What

Two changes to make publishing work and make what it does legible:

1. `lerna.json` gains `"npmClient": "pnpm"`.
2. `publish.yml` drops its second publish step, the GitHub Packages mirror.

## Why publishing was broken

`lerna.json` was only `{"version": "independent"}`. With no `npmClient`, lerna looks for a `workspaces` field in `package.json` — this repository declares its packages in `pnpm-workspace.yaml`, so lerna resolved **zero** packages and every run on `main` died with:

```
lerna ERR! EWORKSPACES Lerna is expecting to able to resolve the "workspaces" configuration
from your package manager ... (B) Alternatively, if you are using pnpm as your package
manager, make sure you set "npmClient": "pnpm" in your lerna.json
```

That is the fix lerna itself prescribes. Verified locally: `lerna list` goes from a hard failure to `found 47 packages`.

## Why the mirror goes

The workflow published everything a second time to `npm.pkg.github.com`. Nothing installs from there — the only references to that host anywhere are in this workflow. Eight packages (`dependency-cleaner`, `gesture-observer`, `glob-link`, `gltf-optimizer`, `orbit-transform`, `package-builder`, `router`, `trackball-transform`) had never reached it at all, so repairing lerna would have published those eight there for the first time, built from today's tree under version numbers whose npm tarballs were built months earlier. Two registries disagreeing about what a version contains is worse than one registry.

One registry also makes the blast radius readable, which matters because this workflow runs on every push to `main`.

## What merging this releases

`lerna publish from-package` publishes any package whose version is not already in the registry. Against npm today, that is exactly one:

| Package | Local | Registry |
| --- | --- | --- |
| `@damienmortini/typescript-config` | 0.0.19 | 0.0.18 |

That bump is `1f5a1859` (restore webgpu types + target, add `skipLibCheck`), already reviewed and on `main`. The other 46 match the registry exactly and are no-ops. After this, the workflow is a no-op on any push that does not bump a version.

## Follow-up, not in this PR

Twelve packages have source commits since their current version was set, so their published tarballs are stale — `server` by 32 commits. Fixing the pipeline does not release them; only version bumps will. That is a separate PR.

## Noticed, not touched

- `nrwl/nx-set-shas@v3` in this workflow only feeds the `nx affected` lines that are commented out two lines below it. Dead, but unrelated to this change.
- `minimatch@10` hoists against the top-level `brace-expansion@1`, which has no named `expand` export, so it throws on load. Only the `package.json`-workspaces path this change stops using reaches it, so the crash disappears here rather than being fixed.