### PR TITLE
Bump the twelve packages whose source moved past their released version

### DIFF
--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/animation",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "homepage": "https://github.com/damienmortini/lib/tree/main/packages/animation",
   "bugs": "https://github.com/damienmortini/lib/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/core",
-  "version": "0.2.163",
+  "version": "0.2.164",
   "description": "Helpers library for the web.",
   "keywords": [
     "math",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/eslint-config",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "ESLint config",
   "homepage": "https://github.com/damienmortini/lib/tree/main/packages/eslint-config",
   "bugs": "https://github.com/damienmortini/lib/issues",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/generator",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "description": "Generator to create boilerplate files",
   "keywords": [
     "generator",

--- a/packages/gltf-optimizer/package.json
+++ b/packages/gltf-optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/gltf-optimizer",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "homepage": "https://github.com/damienmortini/lib/tree/main/packages/gltf-optimizer",
   "bugs": "https://github.com/damienmortini/lib/issues",
   "repository": {

--- a/packages/gltf/package.json
+++ b/packages/gltf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/gltf",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "GLTF Helpers",
   "keywords": [
     "gltf"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/math",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "Math Helpers",
   "keywords": [
     "math"

--- a/packages/package-builder/package.json
+++ b/packages/package-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/package-builder",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "homepage": "https://github.com/damienmortini/lib/tree/main/packages/package-builder",
   "bugs": "https://github.com/damienmortini/lib/issues",
   "repository": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/router",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/damienmortini/lib/tree/main/packages/router",
   "bugs": "https://github.com/damienmortini/lib/issues",
   "repository": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/server",
-  "version": "1.0.91",
+  "version": "1.1.0",
   "description": "Simple live reloading HTTP2 server for development",
   "keywords": [
     "server",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/server",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "description": "Simple live reloading HTTP2 server for development",
   "keywords": [
     "server",

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/three",
-  "version": "0.1.204",
+  "version": "0.1.205",
   "description": "Three.js helpers",
   "keywords": [
     "three",

--- a/packages/webgl/package.json
+++ b/packages/webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damienmortini/webgl",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "WebGL Helpers",
   "keywords": [
     "webgl"


### PR DESCRIPTION
## What

Twelve version bumps, one line each. No source changes.

## Why

Publishing has been broken long enough that versions stopped being bumped alongside the code, so npm serves tarballs older than the source that names them. Repairing the pipeline does not fix that on its own: `lerna publish from-package` only publishes versions the registry lacks, so a package whose version was never bumped stays stale forever.

| Package | | | Drift |
| --- | --- | --- | --- |
| `@damienmortini/server` | 1.0.90 | **1.1.0** | **32 commits** |
| `@damienmortini/animation` | 0.0.15 | 0.0.16 | 3 commits |
| `@damienmortini/math` | 0.0.28 | 0.0.29 | 3 commits |
| `@damienmortini/package-builder` | 0.0.11 | 0.0.12 | 3 commits |
| `@damienmortini/core` | 0.2.163 | 0.2.164 | 1 commit |
| `@damienmortini/eslint-config` | 0.0.32 | 0.0.33 | 1 commit |
| `@damienmortini/generator` | 0.0.132 | 0.0.133 | 1 commit |
| `@damienmortini/gltf` | 0.0.32 | 0.0.33 | 1 commit |
| `@damienmortini/gltf-optimizer` | 0.0.23 | 0.0.24 | 1 commit |
| `@damienmortini/router` | 0.0.2 | 0.0.3 | 1 commit |
| `@damienmortini/three` | 0.1.204 | 0.1.205 | 1 commit |
| `@damienmortini/webgl` | 0.0.42 | 0.0.43 | 1 commit |

`package-builder@0.0.12` matters most in practice: the released `0.0.11` cannot emit declarations at all, which is what #73 fixed.

## Why server is minor and the rest are patch

`server` is the only package past 1.0.0, so semver actually constrains it, and its 32 commits include seven that add API — `--base` sub-path mounting, local development CA certificate signing, generated import maps, on-demand resolution of computed dynamic imports, bare import rewriting for workers, directory listings without an index, and ETag revalidation with gzip and response caching.

Checked for breaking changes and found none:

- `Read auth from SERVER_AUTH` (`d952e42a`) is additive — `auth ??= process.env.SERVER_AUTH`, so `--auth` still works.
- `Take the served root as a parameter, not process.cwd()` (`612df3b4`) does not change a signature. `rootPath` was already a `Server` option; module resolution now honours it instead of snapshotting `process.cwd()`, a path that previously only emitted a warning and resolved against the wrong tree.

So 1.1.0, not 2.0.0. The other eleven are all below 1.0.0, and their drift is lint gates, type refinements and internal refactors, so they stay patch.

## How the twelve were chosen

For each package, find the commit that last set its current `version`, then count commits touching that package's source afterwards, excluding its own `package.json`. Non-empty means the released tarball is behind. Measuring against "when did `package.json` last change" gives the wrong answer, because `e75c9728` (dependency upgrade) touched all 47 and would mask every drift.

Internal dependencies are all `workspace:*`, so no dependent range needed updating.

## Merge order

This needs the publishing fix (#74) to land first, otherwise the run on `main` still dies at `EWORKSPACES` and these versions sit unreleased until the next push. With that in, merging this publishes the twelve above plus `typescript-config@0.0.19`.

Verified: build, lint and the full test suite pass on this branch.