### PR TITLE
server: reload on a stylesheet change

### DIFF
--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -175,6 +175,25 @@ describe('live-reload client script', () => {
     ok(await fetchLiveReloadState(boundPort(watchingServer)) !== state, 'a refresh must move the token');
   });
 
+  // Stylesheets used to be skipped here, on the assumption that a page swaps them
+  // in without a reload. Nothing does that for CSS imported as a module script into
+  // `adoptedStyleSheets`: the sheet is cached in the module map and carries no href,
+  // so the edit is simply invisible. A page that can swap its own stylesheets cancels
+  // the announcement instead — that hatch is tested above.
+  it('refreshes when a served stylesheet changes', async () => {
+    const stylesheet = join(rootPath, 'style.css');
+    await writeFile(stylesheet, 'body { color: red; }');
+    // Only files that have been served are watched, so the fetch is what arms this.
+    await fetchBody(boundPort(watchingServer), '/style.css');
+    const state = await fetchLiveReloadState(boundPort(watchingServer));
+    await writeFile(stylesheet, 'body { color: blue; }');
+    // The watcher polls, so the refresh lands a moment after the write.
+    const deadline = Date.now() + 10_000;
+    while (await fetchLiveReloadState(boundPort(watchingServer)) === state) {
+      ok(Date.now() < deadline, 'a stylesheet change must move the state token');
+    }
+  });
+
   it('injects nothing when watch is off', async () => {
     const body = await fetchBody(boundPort(plainServer), '/index.html');
     ok(!body.includes('EventSource'), 'expected no live-reload client without watch');

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -468,7 +468,6 @@ export class Server {
           interval: 200,
         })
           .on('change', (changedPath) => {
-            if (changedPath.endsWith('.css') || changedPath.endsWith('.css.map')) return;
             if (verbose) {
               console.log(`${changedPath} just changed, refresh.`);
             }


### PR DESCRIPTION
The live-reload watcher returned early on any changed path ending in `.css` or `.css.map`, on the assumption that a page swaps a stylesheet in without a reload — true for `<link rel="stylesheet">`, where a href swap or a DevTools live-edit updates the page in place.

Nothing does that for CSS imported as a module script (`import style from './x.css' with { type: 'css' }`) into `adoptedStyleSheets`: the sheet is cached in the module map and carries no `href`, so nothing generic can find or refetch it. The edit was simply invisible until a manual refresh, with no message saying why.

So a `.css` change now refreshes like a `.js` change. A page that can swap its own stylesheets keeps the escape hatch it already had: the injected client dispatches a cancelable `server:livereload` event before reloading.

The new test fetches a stylesheet (only served files are watched), rewrites it, and waits for the state token to move; it fails with the skip put back.